### PR TITLE
Return message hash from sendGossipMessage in Plumtree

### DIFF
--- a/plumtree/src/main/java/org/apache/tuweni/plumtree/State.java
+++ b/plumtree/src/main/java/org/apache/tuweni/plumtree/State.java
@@ -244,10 +244,13 @@ public final class State {
    * Sends a gossip message to all peers, according to their status.
    * 
    * @param message the message to propagate
+   * @return The associated hash of the message
    */
-  public void sendGossipMessage(Bytes message) {
-    MessageHandler handler = messageHandlers.computeIfAbsent(messageHashingFunction.hash(message), MessageHandler::new);
+  public Bytes sendGossipMessage(Bytes message) {
+    Bytes messageHash = messageHashingFunction.hash(message);
+    MessageHandler handler = messageHandlers.computeIfAbsent(messageHash, MessageHandler::new);
     handler.fullMessageReceived(null, message);
+    return messageHash;
   }
 
   void processQueue() {


### PR DESCRIPTION
change made: 
- modified sendGossipMessage in plumtree to return the message hash

reason:
- once a message is gossiped, i would like to know the message hash so that I can ignore the message if it is gossiped back to the original sender

currently, i work around the issue in Artemis like this:

```java

  public void onNewUnprocessedBlock(BeaconBlock block) {
    Bytes bytes = block.toBytes();
    state.sendGossipMessage(bytes);
    // TODO: this will be modified once Tuweni merges https://github.com/apache/incubator-tuweni/pull/3
    this.receivedMessages.put(Hash.sha2_256(bytes).toHexString(), true);
  }
```