### PR TITLE
Correct encoding behavior for vector of non-homogeneous Bytes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -416,6 +416,12 @@ allprojects {
                 organization = 'Apache'
                 organizationUrl = 'https://tuweni.apache.org'
               }
+              developer {
+                name = 'Steven J Schroeder'
+                email = 'sjs@apache.org'
+                organization = 'Apache'
+                organizationUrl = 'https://tuweni.apache.org'
+              }
             }
             issueManagement {
               system = "jira"

--- a/ssz/src/main/java/org/apache/tuweni/ssz/SSZ.java
+++ b/ssz/src/main/java/org/apache/tuweni/ssz/SSZ.java
@@ -547,8 +547,15 @@ public final class SSZ {
     }
   }
 
+  static void encodeFixedBytesVectorTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
+    for (Bytes bytes : elements) {
+      appender.accept(bytes);
+    }
+  }
+
   static void encodeBytesVectorTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
     for (Bytes bytes : elements) {
+      appender.accept(encodeLong(bytes.size(), 32));
       appender.accept(bytes);
     }
   }

--- a/ssz/src/main/java/org/apache/tuweni/ssz/SSZ.java
+++ b/ssz/src/main/java/org/apache/tuweni/ssz/SSZ.java
@@ -154,8 +154,7 @@ public final class SSZ {
     appender.accept(value);
   }
 
-  static void encodeFixedBytesTo(int byteLength, Bytes value, Consumer<Bytes> appender) {
-    checkArgument(byteLength == value.size(), "byteLength must be the same size as the value being encoded");
+  static void encodeFixedBytesTo(Bytes value, Consumer<Bytes> appender) {
     appender.accept(value);
   }
 
@@ -560,12 +559,11 @@ public final class SSZ {
     }
   }
 
-  static void encodeFixedBytesListTo(int byteLength, List<? extends Bytes> elements, Consumer<Bytes> appender) {
+  static void encodeFixedBytesListTo(List<? extends Bytes> elements, Consumer<Bytes> appender) {
     // pre-calculate the list size - relies on knowing how encodeBytesTo does its serialization, but is worth it
     // to avoid having to pre-serialize all the elements
     long listSize = 0;
     for (Bytes bytes : elements) {
-      listSize += 4;
       listSize += bytes.size();
       if (listSize > Integer.MAX_VALUE) {
         throw new IllegalArgumentException("Cannot serialize list: overall length is too large");
@@ -573,21 +571,7 @@ public final class SSZ {
     }
     appender.accept(encodeUInt32(listSize));
     for (Bytes bytes : elements) {
-      encodeFixedBytesTo(byteLength, bytes, appender);
-    }
-  }
-
-  static void encodeFixedBytesListTo(
-      long listSize,
-      int byteLength,
-      List<? extends Bytes> elements,
-      Consumer<Bytes> appender) {
-    checkArgument(listSize > 0, "Cannot serialize list: list size must be positive");
-    if (listSize > Integer.MAX_VALUE) {
-      throw new IllegalArgumentException("Cannot serialize list: overall length is too large");
-    }
-    for (Bytes bytes : elements) {
-      encodeFixedBytesTo(byteLength, bytes, appender);
+      encodeFixedBytesTo(bytes, appender);
     }
   }
 

--- a/ssz/src/main/java/org/apache/tuweni/ssz/SSZWriter.java
+++ b/ssz/src/main/java/org/apache/tuweni/ssz/SSZWriter.java
@@ -322,7 +322,7 @@ public interface SSZWriter {
    * @param elements the bytes to write as a list
    */
   default void writeFixedBytesVector(List<? extends Bytes> elements) {
-    SSZ.encodeBytesVectorTo(elements, this::writeSSZ);
+    SSZ.encodeFixedBytesVectorTo(elements, this::writeSSZ);
   }
 
   /**

--- a/ssz/src/main/java/org/apache/tuweni/ssz/SSZWriter.java
+++ b/ssz/src/main/java/org/apache/tuweni/ssz/SSZWriter.java
@@ -71,8 +71,8 @@ public interface SSZWriter {
    * @param value the byte array to encode
    * @throws IllegalArgumentException if the byteLength is not the same size as value.
    */
-  default void writeFixedBytes(int byteLength, Bytes value) {
-    SSZ.encodeFixedBytesTo(byteLength, value, this::writeSSZ);
+  default void writeFixedBytes(Bytes value) {
+    SSZ.encodeFixedBytesTo(value, this::writeSSZ);
   }
 
   /**
@@ -311,8 +311,8 @@ public interface SSZWriter {
    * @param byteLength the number of bytes in each element
    * @param elements the known-size bytes to write as a list
    */
-  default void writeFixedBytesList(int byteLength, List<? extends Bytes> elements) {
-    SSZ.encodeFixedBytesListTo(byteLength, elements, this::writeSSZ);
+  default void writeFixedBytesList(List<? extends Bytes> elements) {
+    SSZ.encodeFixedBytesListTo(elements, this::writeSSZ);
   }
 
   /**

--- a/ssz/src/test/java/org/apache/tuweni/ssz/BytesSSZWriterTest.java
+++ b/ssz/src/test/java/org/apache/tuweni/ssz/BytesSSZWriterTest.java
@@ -24,6 +24,7 @@ import org.apache.tuweni.units.bigints.UInt256;
 
 import java.math.BigInteger;
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.common.base.Charsets;
 import org.junit.jupiter.api.Test;
@@ -419,6 +420,84 @@ class BytesSSZWriterTest {
   @Test
   void shouldWriteUtilListsOfBooleans() {
     assertEquals(fromHexString("0400000000010100"), SSZ.encodeBooleanList(Arrays.asList(false, true, true, false)));
+  }
+
+  @Test
+  void shouldWriteVectorOfHomogeneousBytes() {
+    // Per the pre-SOS SSZ spec, neither the vector nor the bytes should have a mixin.
+    List<Bytes32> elements = Arrays.asList(
+        Bytes32.fromHexString("0x01"),
+        Bytes32.fromHexString("0x02"),
+        Bytes32.fromHexString("0x03"),
+        Bytes32.fromHexString("0x04"),
+        Bytes32.fromHexString("0x05"));
+    assertEquals(
+        fromHexString(
+            "0x0000000000000000000000000000000000000000000000000000000000000001"
+                + "0000000000000000000000000000000000000000000000000000000000000002"
+                + "0000000000000000000000000000000000000000000000000000000000000003"
+                + "0000000000000000000000000000000000000000000000000000000000000004"
+                + "0000000000000000000000000000000000000000000000000000000000000005"),
+        SSZ.encode(writer -> writer.writeFixedBytesVector(elements)));
+  }
+
+  @Test
+  void shouldWriteVectorOfNonHomogeneousBytes() {
+    // Per the pre-SOS SSZ spec, the vector itself should not have a mixin, but the individual bytes elements should.
+    List<Bytes32> elements = Arrays.asList(
+        Bytes32.fromHexString("0x01"),
+        Bytes32.fromHexString("0x02"),
+        Bytes32.fromHexString("0x03"),
+        Bytes32.fromHexString("0x04"),
+        Bytes32.fromHexString("0x05"));
+    assertEquals(
+        fromHexString(
+            "0x200000000000000000000000000000000000000000000000000000000000000000000001"
+                + "200000000000000000000000000000000000000000000000000000000000000000000002"
+                + "200000000000000000000000000000000000000000000000000000000000000000000003"
+                + "200000000000000000000000000000000000000000000000000000000000000000000004"
+                + "200000000000000000000000000000000000000000000000000000000000000000000005"),
+        SSZ.encode(writer -> writer.writeVector(elements)));
+  }
+
+  @Test
+  void shouldWriteListOfHomogeneousBytes() {
+    // Per the pre-SOS SSZ spec, the list iself should have a mixin, but the bytes elements should not.
+    List<Bytes32> elements = Arrays.asList(
+        Bytes32.fromHexString("0x01"),
+        Bytes32.fromHexString("0x02"),
+        Bytes32.fromHexString("0x03"),
+        Bytes32.fromHexString("0x04"),
+        Bytes32.fromHexString("0x05"));
+    assertEquals(
+        fromHexString(
+            "0xA0000000"
+                + "0000000000000000000000000000000000000000000000000000000000000001"
+                + "0000000000000000000000000000000000000000000000000000000000000002"
+                + "0000000000000000000000000000000000000000000000000000000000000003"
+                + "0000000000000000000000000000000000000000000000000000000000000004"
+                + "0000000000000000000000000000000000000000000000000000000000000005"),
+        SSZ.encode(writer -> writer.writeFixedBytesList(elements)));
+  }
+
+  @Test
+  void shouldWriteListOfNonHomogeneousBytes() {
+    // Per the pre-SOS SSZ spec, both the vector itself and the individual bytes elements should have a length mixin.
+    List<Bytes32> elements = Arrays.asList(
+        Bytes32.fromHexString("0x01"),
+        Bytes32.fromHexString("0x02"),
+        Bytes32.fromHexString("0x03"),
+        Bytes32.fromHexString("0x04"),
+        Bytes32.fromHexString("0x05"));
+    assertEquals(
+        fromHexString(
+            "0xB4000000"
+                + "200000000000000000000000000000000000000000000000000000000000000000000001"
+                + "200000000000000000000000000000000000000000000000000000000000000000000002"
+                + "200000000000000000000000000000000000000000000000000000000000000000000003"
+                + "200000000000000000000000000000000000000000000000000000000000000000000004"
+                + "200000000000000000000000000000000000000000000000000000000000000000000005"),
+        SSZ.encode(writer -> writer.writeBytesList(elements)));
   }
 
   @Test


### PR DESCRIPTION
Correct encoding behavior for vector of non-homogeneous Bytes.

Both vectors of homogeneous (fixed/exact) bytes and vectors of non-homogeneous bytes (which require a mixin) were encoded without the element size mixin. This corrects that behavior.