### PR TITLE
On a server ending a scuttlebutt RPC stream, the client should send a final close message to close its end of the stream.

### DIFF
--- a/scuttlebutt-rpc/src/main/java/org/apache/tuweni/scuttlebutt/rpc/RPCCodec.java
+++ b/scuttlebutt-rpc/src/main/java/org/apache/tuweni/scuttlebutt/rpc/RPCCodec.java
@@ -143,7 +143,12 @@ public final class RPCCodec {
   public static Bytes encodeStreamEndRequest(int requestNumber) throws JsonProcessingException {
     Boolean bool = Boolean.TRUE;
     byte[] bytes = mapper.writeValueAsBytes(bool);
-    return encodeRequest(Bytes.wrap(bytes), requestNumber, RPCFlag.EndOrError.END);
+    return encodeRequest(
+        Bytes.wrap(bytes),
+        requestNumber,
+        RPCFlag.EndOrError.END,
+        RPCFlag.BodyType.JSON,
+        RPCFlag.Stream.STREAM);
   }
 
   /**


### PR DESCRIPTION
See the "source example" section of the protocol docs: https://ssbc.github.io/scuttlebutt-protocol-guide/#rpc-protocol