### PR TITLE
Fix bug with scuttlebutt boxstream segments not being formed properly

### DIFF
--- a/scuttlebutt-handshake/src/main/java/org/apache/tuweni/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/org/apache/tuweni/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -137,7 +137,6 @@ final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, Se
 
   private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
     int messages = (int) Math.ceil((double) message.size() / 4096d);
-    Bytes[] encryptedMessages = new Bytes[messages];
 
     ArrayList<Bytes> bytes = breakIntoParts(message);
 

--- a/scuttlebutt-handshake/src/main/java/org/apache/tuweni/scuttlebutt/handshake/SecureScuttlebuttStream.java
+++ b/scuttlebutt-handshake/src/main/java/org/apache/tuweni/scuttlebutt/handshake/SecureScuttlebuttStream.java
@@ -18,7 +18,9 @@ import org.apache.tuweni.crypto.sodium.SHA256Hash;
 import org.apache.tuweni.crypto.sodium.SecretBox;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, SecureScuttlebuttStreamServer {
 
@@ -136,17 +138,36 @@ final class SecureScuttlebuttStream implements SecureScuttlebuttStreamClient, Se
   private Bytes encrypt(Bytes message, SecretBox.Key clientToServerKey, MutableBytes clientToServerNonce) {
     int messages = (int) Math.ceil((double) message.size() / 4096d);
     Bytes[] encryptedMessages = new Bytes[messages];
-    for (int i = 0; i < messages; i++) {
-      Bytes encryptedMessage = encryptMessage(
-          message.slice(i * 4096, Math.min((i + 1) * 4096, message.size() - i * 4096)),
-          clientToServerKey,
-          clientToServerNonce);
-      encryptedMessages[i] = encryptedMessage;
-    }
-    return Bytes.concatenate(encryptedMessages);
+
+    ArrayList<Bytes> bytes = breakIntoParts(message);
+
+    List<Bytes> segments =
+        bytes.stream().map(slice -> encryptMessage(slice, clientToServerKey, clientToServerNonce)).collect(
+            Collectors.toList());
+
+    return Bytes.concatenate(segments.toArray(new Bytes[] {}));
   }
 
+  private ArrayList<Bytes> breakIntoParts(Bytes message) {
+
+    byte[] original = message.toArray();
+
+    int chunk = 4096;
+
+    ArrayList<Bytes> result = new ArrayList<>();
+    for (int i = 0; i < original.length; i += chunk) {
+      byte[] bytes = Arrays.copyOfRange(original, i, Math.min(original.length, i + chunk));
+
+      Bytes wrap = Bytes.wrap(bytes);
+      result.add(wrap);
+    }
+
+    return result;
+  }
+
+
   private Bytes encryptMessage(Bytes message, SecretBox.Key key, MutableBytes nonce) {
+
     SecretBox.Nonce headerNonce = null;
     SecretBox.Nonce bodyNonce = null;
     try {

--- a/scuttlebutt-rpc/src/test/java/org/apache/tuweni/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/org/apache/tuweni/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
@@ -12,6 +12,18 @@
  */
 package org.apache.tuweni.scuttlebutt.rpc.mux;
 
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -145,6 +157,38 @@ public class PatchworkIntegrationTest {
       HashMap<String, String> params = new HashMap<>();
       params.put("type", "post");
       params.put("text", "test test " + i);
+
+      RPCAsyncRequest asyncRequest = new RPCAsyncRequest(new RPCFunction("publish"), Arrays.asList(params));
+
+      AsyncResult<RPCResponse> rpcMessageAsyncResult = rpcHandler.makeAsyncRequest(asyncRequest);
+
+      results.add(rpcMessageAsyncResult);
+
+    }
+
+    List<RPCResponse> rpcMessages = AsyncResult.combine(results).get();
+
+    rpcMessages.forEach(msg -> System.out.println(msg.asString()));
+  }
+
+  @Test
+  @Disabled
+  /**
+   * We expect this to complete the AsyncResult with an exception.
+   */
+  public void postMessageThatIsTooLong(@VertxInstance Vertx vertx) throws Exception {
+
+    RPCHandler rpcHandler = makeRPCHandler(vertx);
+
+    List<AsyncResult<RPCResponse>> results = new ArrayList<>();
+
+    String longString = new String(new char[40000]).replace("\0", "a");
+
+    for (int i = 0; i < 20; i++) {
+      // Note: in a real use case, this would more likely be a Java class with these fields
+      HashMap<String, String> params = new HashMap<>();
+      params.put("type", "post");
+      params.put("text", longString);
 
       RPCAsyncRequest asyncRequest = new RPCAsyncRequest(new RPCFunction("publish"), Arrays.asList(params));
 

--- a/scuttlebutt-rpc/src/test/java/org/apache/tuweni/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
+++ b/scuttlebutt-rpc/src/test/java/org/apache/tuweni/scuttlebutt/rpc/mux/PatchworkIntegrationTest.java
@@ -11,19 +11,6 @@
  * specific language governing permissions and limitations under the License.
  */
 package org.apache.tuweni.scuttlebutt.rpc.mux;
-
-/*
- * Copyright 2019 ConsenSys AG.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- */
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 


### PR DESCRIPTION
I encountered a bug whereby RPC messages with a large body length (for example 20kb) resulted in the server closing the connection immediately. In the application I'm building with this library, there is a custom RPC handler which can accept large messages as parameters.

I've narrowed this down to being an issue with the `slice` method on `Bytes` in the `encrypt` method of `SecureScuttlebuttStream`. It would appear that the `.size()` method retains the size of the original array that backs the slice, despite the `offset` and `end` that are set. This means that body length is set wrong in the box-stream headers, and I'm assuming the server closes the connection because it reads garbage rather than a header when it starts reading from the end of the length.

You can reproduce this error by:

* Copy the new `postMessageThatIsTooLong` test from this pull request to your local version of master.
* Run the test
* Observe that the connection is reset by the peer (server.)

If you step through debug the test in your IDE and set a breakpoint in the `encryptMessage` you'll notice that the encryptedBody is longer than 4096 bytes, and the `size` call returns more than `4096` too (for the second iteration around the loop.)

When this same test is ran with the new `encrypt` implementation, the server returns a 'message too long' error response for the `publish` RPC call and the connection remains open (as expected for the `publish` method which has a maximum message length limit.)

I'm hoping that you can help me fix the underlying cause with the `slice` method for the `Bytes` implementation(s) etc since you're more familiar with that module. 

The implementation in this pull request is probably less efficient but it works as a workaround for now.


