### PR TITLE
make signatureData function public

### DIFF
--- a/eth/src/main/java/org/apache/tuweni/eth/Transaction.java
+++ b/eth/src/main/java/org/apache/tuweni/eth/Transaction.java
@@ -415,7 +415,7 @@ public final class Transaction {
     return SECP256K1.sign(signatureData(nonce, gasPrice, gasLimit, to, value, payload, chainId), keyPair);
   }
 
-  private static Bytes signatureData(
+  public static Bytes signatureData(
       UInt256 nonce,
       Wei gasPrice,
       Gas gasLimit,


### PR DESCRIPTION
One issue that I've had is that you need the keypair to use the Transaction class. 

By making this function public, it is possible to prepare the transaction data to sign, sign it somewhere else, and then build the transaction object with the signature result