### PR TITLE
Add functionality for querying scuttlebutt gossip table and social graph

### DIFF
--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/NetworkService.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/NetworkService.java
@@ -15,23 +15,44 @@ package org.apache.tuweni.scuttlebutt.lib;
 import org.apache.tuweni.concurrent.AsyncResult;
 import org.apache.tuweni.scuttlebutt.Invite;
 import org.apache.tuweni.scuttlebutt.MalformedInviteCodeException;
+import org.apache.tuweni.scuttlebutt.lib.model.Peer;
+import org.apache.tuweni.scuttlebutt.lib.model.PeerStateChange;
+import org.apache.tuweni.scuttlebutt.lib.model.StreamHandler;
 import org.apache.tuweni.scuttlebutt.rpc.RPCAsyncRequest;
 import org.apache.tuweni.scuttlebutt.rpc.RPCFunction;
 import org.apache.tuweni.scuttlebutt.rpc.RPCResponse;
+import org.apache.tuweni.scuttlebutt.rpc.RPCStreamRequest;
 import org.apache.tuweni.scuttlebutt.rpc.mux.Multiplexer;
+import org.apache.tuweni.scuttlebutt.rpc.mux.ScuttlebuttStreamHandler;
+import org.apache.tuweni.scuttlebutt.rpc.mux.exceptions.ConnectionClosedException;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A service for operations that connect nodes together and other network related operations
- *
+ * <p>
+ * Assumes the standard 'ssb-gossip' plugin is installed and enabled on the node that we're connected to (or that RPC
+ * functions meeting its manifest's contract are available.).
+ * <p>
  * Should not be constructed directly, should be used via an ScuttlebuttClient instance.
  */
 public class NetworkService {
 
   private final Multiplexer multiplexer;
+
+  // We don't represent all the fields returned over RPC in our java classes, so we configure the mapper
+  // to ignore JSON fields without a corresponding Java field
+  private final ObjectMapper mapper =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   protected NetworkService(Multiplexer multiplexer) {
     this.multiplexer = multiplexer;
@@ -66,7 +87,7 @@ public class NetworkService {
   /**
    * Redeems an invite issued by another node. If successful, the node will connect to the other node and each node will
    * befriend each other.
-   * 
+   *
    * @param invite
    * @return
    */
@@ -81,6 +102,83 @@ public class NetworkService {
       return AsyncResult.exceptional(ex);
     }
   }
+
+  /**
+   * Queries for the list of peers the instance is connected to.
+   *
+   * @return
+   */
+  public AsyncResult<List<Peer>> getConnectedPeers() {
+    return getAllKnownPeers().thenApply(
+        peers -> peers.stream().filter(peer -> peer.getState().equals("connected")).collect(Collectors.toList()));
+  }
+
+  /**
+   * Queries for all the peers the instance is aware of in its gossip table.
+   *
+   * @return
+   */
+  public AsyncResult<List<Peer>> getAllKnownPeers() {
+    RPCFunction function = new RPCFunction(Arrays.asList("gossip"), "peers");
+    RPCAsyncRequest request = new RPCAsyncRequest(function, Arrays.asList());
+
+    try {
+      return multiplexer.makeAsyncRequest(request).then(rpcResponse -> {
+        try {
+          List<Peer> peers = rpcResponse.asJSON(mapper, new TypeReference<List<Peer>>() {});
+          return AsyncResult.completed(peers);
+        } catch (IOException e) {
+          return AsyncResult.exceptional(e);
+        }
+      });
+    } catch (JsonProcessingException e) {
+      return AsyncResult.exceptional(e);
+    }
+  }
+
+  /**
+   * Opens a stream of peer connection state changes.
+   *
+   * @param streamHandler A function that can be invoked to instantiate a stream handler to pass events to, with a given
+   *        runnable to close the stream early
+   * @throws JsonProcessingException If the stream could be opened due to an error serializing the request
+   * @throws ConnectionClosedException if the stream could not be opened due to the connection being closed
+   */
+  public void createChangesStream(Function<Runnable, StreamHandler<PeerStateChange>> streamHandler)
+      throws JsonProcessingException,
+      ConnectionClosedException {
+    RPCFunction function = new RPCFunction(Arrays.asList("gossip"), "changes");
+
+    RPCStreamRequest request = new RPCStreamRequest(function, Arrays.asList());
+
+    multiplexer.openStream(request, (closer) -> new ScuttlebuttStreamHandler() {
+
+      StreamHandler<PeerStateChange> changeStream = streamHandler.apply(closer);
+
+      @Override
+      public void onMessage(RPCResponse message) {
+        try {
+          PeerStateChange peerStateChange = message.asJSON(mapper, PeerStateChange.class);
+          changeStream.onMessage(peerStateChange);
+        } catch (IOException e) {
+          changeStream.onStreamError(e);
+          closer.run();
+        }
+      }
+
+      @Override
+      public void onStreamEnd() {
+        changeStream.onStreamEnd();
+      }
+
+      @Override
+      public void onStreamError(Exception ex) {
+        changeStream.onStreamError(ex);
+      }
+    });
+
+  }
+
 
   private Invite inviteFromRPCResponse(RPCResponse response) throws MalformedInviteCodeException {
     String rawInviteCode = response.asString();

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/ScuttlebuttClient.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/ScuttlebuttClient.java
@@ -26,7 +26,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ScuttlebuttClient {
 
   private final Multiplexer multiplexer;
-  private final ObjectMapper mapper;
+
+  private final FeedService feedService;
 
   /**
    *
@@ -35,7 +36,7 @@ public class ScuttlebuttClient {
    */
   protected ScuttlebuttClient(Multiplexer multiplexer, ObjectMapper mapper) {
     this.multiplexer = multiplexer;
-    this.mapper = mapper;
+    this.feedService = new FeedService(multiplexer, mapper);
   }
 
   /**
@@ -53,8 +54,18 @@ public class ScuttlebuttClient {
    * @return
    */
   public FeedService getFeedService() {
-    return new FeedService(multiplexer, mapper);
+    return feedService;
   }
+
+  /**
+   * A service for operations concerning social connections and updating the instance's profile
+   *
+   * @return
+   */
+  public SocialService getSocialService() {
+    return new SocialService(multiplexer, feedService);
+  }
+
 
   /**
    * A service for making lower level requests that are not supported by higher level services.

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/SocialService.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/SocialService.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.tuweni.scuttlebutt.lib;
+
+import org.apache.tuweni.concurrent.AsyncResult;
+import org.apache.tuweni.scuttlebutt.lib.model.Profile;
+import org.apache.tuweni.scuttlebutt.lib.model.UpdateNameMessage;
+import org.apache.tuweni.scuttlebutt.lib.model.query.AboutQuery;
+import org.apache.tuweni.scuttlebutt.lib.model.query.AboutQueryResponse;
+import org.apache.tuweni.scuttlebutt.lib.model.query.IsFollowingQuery;
+import org.apache.tuweni.scuttlebutt.lib.model.query.IsFollowingResponse;
+import org.apache.tuweni.scuttlebutt.lib.model.query.WhoAmIResponse;
+import org.apache.tuweni.scuttlebutt.rpc.RPCAsyncRequest;
+import org.apache.tuweni.scuttlebutt.rpc.RPCFunction;
+import org.apache.tuweni.scuttlebutt.rpc.RPCResponse;
+import org.apache.tuweni.scuttlebutt.rpc.mux.Multiplexer;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Operations for querying the follow graph, and fetching the profiles of users.
+ *
+ * Assumes that the standard 'ssb-about' and 'ssb-friends' plugins are installed on the target instance (or that RPC
+ * functions meeting their manifests' contracts are available.)
+ *
+ * Should not be instantiated directly - an instance should be acquired via the ScuttlebuttClient instance
+ *
+ */
+public class SocialService {
+
+  private final Multiplexer multiplexer;
+  private final FeedService feedService;
+
+  private ObjectMapper mapper = new ObjectMapper();
+
+  protected SocialService(Multiplexer multiplexer, FeedService feedService) {
+    this.multiplexer = multiplexer;
+    this.feedService = feedService;
+  }
+
+  /**
+   * Get the instance's public key (the key used for its identity.)
+   *
+   * @return
+   */
+  public AsyncResult<String> getOwnIdentity() {
+    RPCFunction function = new RPCFunction("whoami");
+
+    RPCAsyncRequest request = new RPCAsyncRequest(function, Arrays.asList());
+
+    try {
+      return multiplexer.makeAsyncRequest(request).then(response -> {
+        try {
+          return AsyncResult.completed(response.asJSON(mapper, WhoAmIResponse.class).getId());
+        } catch (IOException e) {
+          return AsyncResult.exceptional(e);
+        }
+      });
+    } catch (JsonProcessingException e) {
+      return AsyncResult.exceptional(e);
+    }
+  }
+
+  /**
+   * Get the instance's current profile
+   *
+   * @return
+   */
+  public AsyncResult<Profile> getOwnProfile() {
+    return getOwnIdentity().then(identity -> getProfile(identity));
+  }
+
+  /**
+   * Get the profiles of all the users that the instance is following.
+   *
+   * @return
+   */
+  public AsyncResult<List<Profile>> getFollowing() {
+    return getHops().then(followHops -> {
+      List<String> following =
+          followHops.keySet().stream().filter(key -> followHops.get(key) == 1).collect(Collectors.toList());
+
+      return getProfiles(following);
+    });
+  }
+
+  /**
+   * Get the profiles of all the instances that are following the instance.
+   *
+   * @return
+   */
+  public AsyncResult<List<Profile>> getFollowedBy() {
+
+    return getOwnIdentity().then(ownIdentity -> getHops().then(hops -> {
+      Set<String> identities = hops.keySet();
+
+      List<AsyncResult<IsFollowingResponse>> results =
+          identities.stream().map((ident) -> isFollowing(ident, ownIdentity)).collect(Collectors.toList());
+
+      AsyncResult<List<IsFollowingResponse>> allResults = AsyncResult.combine(results);
+
+      AsyncResult<List<String>> ids = allResults.thenApply(
+          queryResults -> queryResults
+              .stream()
+              .filter(result -> result.isFollowing())
+              .map(IsFollowingResponse::getSource)
+              .collect(Collectors.toList()));
+
+      return ids.then(this::getProfiles);
+    }));
+  }
+
+  /**
+   * Get the profiles of all the users that the instance is following that also follow the instance.
+   *
+   * @return
+   */
+  public AsyncResult<List<Profile>> getFriends() {
+
+    return getOwnIdentity().then(ident -> getFollowing().then(following -> {
+
+      List<AsyncResult<IsFollowingResponse>> responses =
+          following.stream().map((follow) -> isFollowing(follow.getKey(), ident)).collect(Collectors.toList());
+
+      return AsyncResult.combine(responses).then(response -> {
+        List<AsyncResult<Profile>> profiles =
+            response.stream().filter(f -> f.isFollowing()).map(item -> getProfile(item.getSource())).collect(
+                Collectors.toList());
+
+        return AsyncResult.combine(profiles);
+      });
+
+    }));
+
+  }
+
+  /**
+   * Gets the profile of a given user
+   *
+   * @param publicKey the public key of the user to get the profile of
+   * @return
+   */
+  public AsyncResult<Profile> getProfile(String publicKey) {
+
+    RPCFunction function = new RPCFunction(Arrays.asList("about"), "latestValues");
+    AboutQuery query = new AboutQuery(publicKey, Arrays.asList("name"));
+    RPCAsyncRequest rpcAsyncRequest = new RPCAsyncRequest(function, Arrays.asList(query));
+
+    try {
+      AsyncResult<RPCResponse> rpcResponseAsyncResult = multiplexer.makeAsyncRequest(rpcAsyncRequest);
+
+      return rpcResponseAsyncResult.then(rpcResponse -> {
+        try {
+          AboutQueryResponse aboutQueryResponse = rpcResponse.asJSON(mapper, AboutQueryResponse.class);
+          return AsyncResult.completed(new Profile(publicKey, aboutQueryResponse.getName()));
+        } catch (IOException e) {
+          return AsyncResult.exceptional(e);
+        }
+      });
+
+    } catch (JsonProcessingException e) {
+      return AsyncResult.exceptional(e);
+    }
+  }
+
+  /**
+   * Set the display name of the instance by posting an 'about' message to the feed.
+   *
+   * @param displayName the instance's new display name
+   * @return the new profile after setting the display name
+   */
+  public AsyncResult<Profile> setDisplayName(String displayName) {
+
+    return getOwnIdentity().then(ownId -> {
+      try {
+        return feedService.publish(new UpdateNameMessage(displayName, ownId)).then(feedMessage -> getProfile(ownId));
+      } catch (JsonProcessingException e) {
+        return AsyncResult.exceptional(e);
+      }
+    });
+  }
+
+  /**
+   * A map of all the instance IDs to how many hops away they are in the social graph.
+   *
+   * @return
+   */
+  private AsyncResult<Map<String, Integer>> getHops() {
+    RPCFunction rpcFunction = new RPCFunction(Arrays.asList("friends"), "hops");
+    RPCAsyncRequest rpcAsyncRequest = new RPCAsyncRequest(rpcFunction, Arrays.asList());
+
+    try {
+      AsyncResult<RPCResponse> rpcResponseAsyncResult = multiplexer.makeAsyncRequest(rpcAsyncRequest);
+
+      return rpcResponseAsyncResult.then(rpcResponse -> {
+
+        try {
+          Map<String, Integer> followHops = rpcResponse.asJSON(mapper, new TypeReference<Map<String, Integer>>() {});
+          return AsyncResult.completed(followHops);
+        } catch (IOException e) {
+          return AsyncResult.exceptional(e);
+        }
+      });
+
+    } catch (JsonProcessingException e) {
+      return AsyncResult.exceptional(e);
+    }
+  }
+
+  /**
+   * Queries whether a given user (source) is following another given user (destination)
+   *
+   * @param source the node we want to check is following the destination
+   * @param destination the destination node
+   * @return
+   */
+  private AsyncResult<IsFollowingResponse> isFollowing(String source, String destination) {
+    RPCFunction function = new RPCFunction(Arrays.asList("friends"), "isFollowing");
+
+    RPCAsyncRequest rpcAsyncRequest =
+        new RPCAsyncRequest(function, Arrays.asList(new IsFollowingQuery(source, destination)));
+
+    try {
+      return multiplexer.makeAsyncRequest(rpcAsyncRequest).then(rpcResponse -> {
+        try {
+          boolean answer = rpcResponse.asJSON(mapper, Boolean.class);
+          return AsyncResult.completed(new IsFollowingResponse(source, destination, answer));
+        } catch (IOException e) {
+          return AsyncResult.exceptional(e);
+        }
+      });
+    } catch (JsonProcessingException e) {
+      return AsyncResult.exceptional(e);
+    }
+  }
+
+  /**
+   * Fetches the profiles of the given list of users.
+   *
+   * @param keys the users to get the profiles of
+   * @return
+   */
+  private AsyncResult<List<Profile>> getProfiles(List<String> keys) {
+
+    List<AsyncResult<Profile>> asyncResultStream = keys.stream().map(this::getProfile).collect(Collectors.toList());
+
+    return AsyncResult.combine(asyncResultStream);
+  }
+
+}

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/Peer.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/Peer.java
@@ -12,25 +12,46 @@
  */
 package org.apache.tuweni.scuttlebutt.lib.model;
 
+public class Peer {
 
-public interface StreamHandler<T> {
+  private String state;
+  private String address;
+  private int port;
+  private String key;
+
+  public Peer() {}
 
   /**
-   * Handles a new item from the result stream.
    *
-   * @param item
+   * @param address the address of the peer used to connect to it
+   * @param port the port of the peer
+   * @param key the public key of the peer
+   * @param state the connection state of the peer
    */
-  void onMessage(T item);
+  public Peer(String address, int port, String key, String state) {
+    this.address = address;
+    this.port = port;
+    this.key = key;
+    this.state = state;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public String getAddress() {
+    return address;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public int getPort() {
+    return port;
+  }
+
+  public String getKey() {
+    return key;
+  }
+
+  public String getState() {
+    if (state == null) {
+      return "unknown";
+    } else {
+      return state;
+    }
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/PeerStateChange.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/PeerStateChange.java
@@ -12,25 +12,40 @@
  */
 package org.apache.tuweni.scuttlebutt.lib.model;
 
+public class PeerStateChange {
 
-public interface StreamHandler<T> {
+  private Peer peer;
+  private String type;
+
+  /*
+    * Empty constructor for serialization
+   */
+  public PeerStateChange() {}
 
   /**
-   * Handles a new item from the result stream.
+   * A change in peer state.
    *
-   * @param item
+   * @param type the state change since the previous state
+   * @param peer the new peer details
    */
-  void onMessage(T item);
+  public PeerStateChange(String type, Peer peer) {
+    this.type = type;
+    this.peer = peer;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public Peer getPeer() {
+    return peer;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public void setPeer(Peer peer) {
+    this.peer = peer;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/Profile.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/Profile.java
@@ -12,25 +12,33 @@
  */
 package org.apache.tuweni.scuttlebutt.lib.model;
 
+/**
+ * Represents a user profile.
+ */
+public class Profile {
 
-public interface StreamHandler<T> {
+  private String key;
+  private String displayName;
+
+  public Profile() {
+
+  }
 
   /**
-   * Handles a new item from the result stream.
    *
-   * @param item
+   * @param key the public key of the user
+   * @param displayName the display name of the user
    */
-  void onMessage(T item);
+  public Profile(String key, String displayName) {
+    this.key = key;
+    this.displayName = displayName;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public String getKey() {
+    return key;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getDisplayName() {
+    return displayName;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/UpdateNameMessage.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/UpdateNameMessage.java
@@ -12,25 +12,37 @@
  */
 package org.apache.tuweni.scuttlebutt.lib.model;
 
+/**
+ * A message that when persisted to the feed updates the name of the given user
+ */
+public class UpdateNameMessage implements ScuttlebuttMessageContent {
 
-public interface StreamHandler<T> {
+  private String about;
+  public String type = "about";
+  public String name = "name";
+
+  public UpdateNameMessage() {}
 
   /**
-   * Handles a new item from the result stream.
    *
-   * @param item
+   * @param name the new name for the user
+   * @param about the public key that the new name should be applied to
    */
-  void onMessage(T item);
+  public UpdateNameMessage(String name, String about) {
+    this.name = name;
+    this.about = about;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public String getAbout() {
+    return about;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public String getType() {
+    return type;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/AboutQuery.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/AboutQuery.java
@@ -10,27 +10,31 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.tuweni.scuttlebutt.lib.model;
+package org.apache.tuweni.scuttlebutt.lib.model.query;
 
+import java.util.List;
 
-public interface StreamHandler<T> {
+public class AboutQuery {
 
-  /**
-   * Handles a new item from the result stream.
-   *
-   * @param item
-   */
-  void onMessage(T item);
+  private List<String> keys;
+  private String dest;
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public AboutQuery() {}
 
   /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
+   * @param dest the object that the 'about' type message refers to (e.g. user profile / message ID.)
+   * @param keys The keys for the 'about' type messages that we're querying
    */
-  void onStreamError(Exception ex);
+  public AboutQuery(String dest, List<String> keys) {
+    this.keys = keys;
+    this.dest = dest;
+  }
+
+  public List<String> getKeys() {
+    return keys;
+  }
+
+  public String getDest() {
+    return dest;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/AboutQueryResponse.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/AboutQueryResponse.java
@@ -10,27 +10,26 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.tuweni.scuttlebutt.lib.model;
+package org.apache.tuweni.scuttlebutt.lib.model.query;
 
+/**
+ * A response to querying for the profile details of a user.
+ */
+public class AboutQueryResponse {
 
-public interface StreamHandler<T> {
+  private String name;
+
+  public AboutQueryResponse() {}
 
   /**
-   * Handles a new item from the result stream.
    *
-   * @param item
+   * @param name the display name of the user
    */
-  void onMessage(T item);
+  public AboutQueryResponse(String name) {
+    this.name = name;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
-
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getName() {
+    return name;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/IsFollowingQuery.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/IsFollowingQuery.java
@@ -10,27 +10,31 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.tuweni.scuttlebutt.lib.model;
+package org.apache.tuweni.scuttlebutt.lib.model.query;
 
+public class IsFollowingQuery {
 
-public interface StreamHandler<T> {
+  private String source;
+  private String dest;
+
+  public IsFollowingQuery() {}
 
   /**
-   * Handles a new item from the result stream.
+   * A query body to check whether the 'source' is following the 'destination' user.
    *
-   * @param item
+   * @param source the source to check
+   * @param dest the target node
    */
-  void onMessage(T item);
+  public IsFollowingQuery(String source, String dest) {
+    this.source = source;
+    this.dest = dest;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public String getSource() {
+    return source;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getDest() {
+    return dest;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/IsFollowingResponse.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/IsFollowingResponse.java
@@ -10,27 +10,38 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.tuweni.scuttlebutt.lib.model;
+package org.apache.tuweni.scuttlebutt.lib.model.query;
 
+public class IsFollowingResponse {
 
-public interface StreamHandler<T> {
+  private String destination;
+  private String source;
+  private boolean following;
+
+  public IsFollowingResponse() {}
 
   /**
-   * Handles a new item from the result stream.
+   * A response to a query on whether 'source' is following 'destination'
    *
-   * @param item
+   * @param source the source node
+   * @param destination the destination node
+   * @param following true if source is following destination, false otherwise
    */
-  void onMessage(T item);
+  public IsFollowingResponse(String source, String destination, boolean following) {
+    this.source = source;
+    this.destination = destination;
+    this.following = following;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
+  public String getDestination() {
+    return destination;
+  }
 
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getSource() {
+    return source;
+  }
+
+  public boolean isFollowing() {
+    return following;
+  }
 }

--- a/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/WhoAmIResponse.java
+++ b/scuttlebutt-client-lib/src/main/java/org/apache/tuweni/scuttlebutt/lib/model/query/WhoAmIResponse.java
@@ -10,27 +10,25 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package org.apache.tuweni.scuttlebutt.lib.model;
+package org.apache.tuweni.scuttlebutt.lib.model.query;
 
+public class WhoAmIResponse {
 
-public interface StreamHandler<T> {
+  private String id;
+
+  public WhoAmIResponse() {
+
+  }
 
   /**
-   * Handles a new item from the result stream.
    *
-   * @param item
+   * @param id the ID of the current user in response to a 'whoami' query
    */
-  void onMessage(T item);
+  public WhoAmIResponse(String id) {
+    this.id = id;
+  }
 
-  /**
-   * Invoked when the stream has been closed.
-   */
-  void onStreamEnd();
-
-  /**
-   * Invoked when there is an error in the stream.
-   *
-   * @param ex the underlying error
-   */
-  void onStreamError(Exception ex);
+  public String getId() {
+    return id;
+  }
 }

--- a/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/FeedStreamTest.java
+++ b/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/FeedStreamTest.java
@@ -66,7 +66,7 @@ public class FeedStreamTest {
 
     CompletableAsyncResult<Optional<FeedMessage>> lastMessage = AsyncResult.incomplete();
 
-    feedService.createFeedStream(new StreamHandler<FeedMessage>() {
+    feedService.createFeedStream((closer) -> new StreamHandler<FeedMessage>() {
 
       Optional<FeedMessage> currentMessage = Optional.empty();
 

--- a/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/PeerInfoTest.java
+++ b/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/PeerInfoTest.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.tuweni.scuttlebutt.lib;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.tuweni.concurrent.AsyncResult;
+import org.apache.tuweni.concurrent.CompletableAsyncResult;
+import org.apache.tuweni.scuttlebutt.Invite;
+import org.apache.tuweni.scuttlebutt.MalformedInviteCodeException;
+import org.apache.tuweni.scuttlebutt.lib.model.Peer;
+import org.apache.tuweni.scuttlebutt.lib.model.PeerStateChange;
+import org.apache.tuweni.scuttlebutt.lib.model.StreamHandler;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class PeerInfoTest {
+
+  private AsyncResult<Void> peerWithNodeUsingInviteCode(ScuttlebuttClient client) throws MalformedInviteCodeException,
+      Exception {
+    String inviteCode = System.getenv("ssb_invite_code");
+
+    if (inviteCode == null) {
+      return AsyncResult.exceptional(
+          new Exception("Test requires an 'ssb_invite_code environment variable with a valid ssb invite code"));
+    } else {
+      return client.getNetworkService().redeemInviteCode(Invite.fromCanonicalForm(inviteCode));
+    }
+  }
+
+
+  @Test
+  @Disabled("Requires a scuttlebutt backend")
+  public void testPeerStream() throws Exception, MalformedInviteCodeException {
+    TestConfig config = TestConfig.fromEnvironment();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult =
+        ScuttlebuttClientFactory.fromNet(new ObjectMapper(), config.getHost(), config.getPort(), config.getKeyPair());
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    CompletableAsyncResult<PeerStateChange> incomplete = AsyncResult.incomplete();
+
+    scuttlebuttClient.getNetworkService().createChangesStream((closer) -> new StreamHandler<PeerStateChange>() {
+      @Override
+      public void onMessage(PeerStateChange item) {
+        if (!incomplete.isDone()) {
+          incomplete.complete(item);
+        }
+
+        closer.run();
+      }
+
+      @Override
+      public void onStreamEnd() {
+
+        if (!incomplete.isDone()) {
+          incomplete.completeExceptionally(new Exception("Stream closed before any items were pushed."));
+        }
+
+      }
+
+      @Override
+      public void onStreamError(Exception ex) {
+        incomplete.completeExceptionally(ex);
+      }
+    });
+
+    ScuttlebuttClient client = scuttlebuttClientLibAsyncResult.get();
+
+    AsyncResult<Void> inviteRedeemed = peerWithNodeUsingInviteCode(client);
+
+    try {
+      inviteRedeemed.get();
+    } catch (Exception ex) {
+      // Not fatal, since we may already have peered
+      System.out.println("Exception while redeeming invite code: " + ex.getMessage());
+    }
+
+    PeerStateChange peerStateChange = incomplete.get(10000, TimeUnit.SECONDS);
+
+    String changeType = peerStateChange.getType();
+
+    assertTrue(changeType != null);
+  }
+
+  @Test
+  @Disabled("Requires a scuttlebutt backend")
+  public void getConnectedPeersTest() throws Exception, MalformedInviteCodeException {
+    TestConfig config = TestConfig.fromEnvironment();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult =
+        ScuttlebuttClientFactory.fromNet(new ObjectMapper(), config.getHost(), config.getPort(), config.getKeyPair());
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    AsyncResult<Void> asyncResult = peerWithNodeUsingInviteCode(scuttlebuttClient);
+
+    try {
+      asyncResult.get();
+    } catch (Exception ex) {
+      // Not fatal, since we may already have peered
+      System.out.println("Exception while redeeming invite code: " + ex.getMessage());
+    }
+
+    AsyncResult<List<Peer>> connectedPeers = scuttlebuttClient.getNetworkService().getConnectedPeers();
+
+    Thread.sleep(10000);
+
+    assertTrue(!connectedPeers.get().isEmpty());
+  }
+
+}

--- a/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/SocialServiceTest.java
+++ b/scuttlebutt-client-lib/src/test/java/org/apache/tuweni/scuttlebutt/lib/SocialServiceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ * to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.apache.tuweni.scuttlebutt.lib;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.tuweni.concurrent.AsyncResult;
+import org.apache.tuweni.crypto.sodium.Signature;
+import org.apache.tuweni.scuttlebutt.lib.model.Profile;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class SocialServiceTest {
+
+  @Test
+  @Disabled("Requires an ssb instance")
+  public void testViewFollowingWithPatchwork() throws Exception {
+
+    Signature.KeyPair localKeys = KeyFileLoader.getLocalKeys();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult =
+        ScuttlebuttClientFactory.fromNet(new ObjectMapper(), "localhost", 8008, localKeys);
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    AsyncResult<List<Profile>> following = scuttlebuttClient.getSocialService().getFollowing();
+
+    List<Profile> profiles = following.get(10, TimeUnit.SECONDS);
+
+    assertTrue(!profiles.isEmpty());
+
+    profiles.stream().forEach(profile -> System.out.println(profile.getDisplayName()));
+
+    System.out.println("Following: " + profiles.size());
+  }
+
+  @Test
+  @Disabled("Requires an ssb instance")
+  public void testViewFollowedByPatchwork() throws Exception {
+    Signature.KeyPair localKeys = KeyFileLoader.getLocalKeys();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult =
+        ScuttlebuttClientFactory.fromNet(new ObjectMapper(), "localhost", 8008, localKeys);
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    AsyncResult<List<Profile>> followedBy = scuttlebuttClient.getSocialService().getFollowedBy();
+
+    List<Profile> profiles = followedBy.get(30, TimeUnit.SECONDS);
+
+    assertTrue(!profiles.isEmpty());
+
+    profiles.stream().forEach(profile -> System.out.println(profile.getDisplayName()));
+
+    System.out.println("Followed by: " + profiles.size());
+  }
+
+  @Test
+  @Disabled("Requires an ssb instance")
+  public void testFriendsWithPatchwork() throws Exception {
+    Signature.KeyPair localKeys = KeyFileLoader.getLocalKeys();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult =
+        ScuttlebuttClientFactory.fromNet(new ObjectMapper(), "localhost", 8008, localKeys);
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    AsyncResult<List<Profile>> friends = scuttlebuttClient.getSocialService().getFriends();
+
+    List<Profile> profiles = friends.get(30, TimeUnit.SECONDS);
+
+    assertTrue(!profiles.isEmpty());
+
+    profiles.stream().forEach(profile -> System.out.println(profile.getDisplayName()));
+
+    System.out.println("Friends: " + profiles.size());
+  }
+
+  @Test
+  @Disabled("Requires an ssb instance")
+  public void testSetDisplayName() throws Exception {
+
+    TestConfig testConfig = TestConfig.fromEnvironment();
+
+    AsyncResult<ScuttlebuttClient> scuttlebuttClientLibAsyncResult = ScuttlebuttClientFactory
+        .fromNet(new ObjectMapper(), testConfig.getHost(), testConfig.getPort(), testConfig.getKeyPair());
+
+    ScuttlebuttClient scuttlebuttClient = scuttlebuttClientLibAsyncResult.get();
+
+    SocialService socialService = scuttlebuttClient.getSocialService();
+
+    String newDisplayName = "Test display name";
+
+    Profile profile = socialService.setDisplayName(newDisplayName).get();
+
+    assertEquals(profile.getDisplayName(), newDisplayName);
+
+    Profile ownProfile = socialService.getOwnProfile().get();
+
+    assertEquals(ownProfile.getDisplayName(), newDisplayName);
+  }
+
+
+}

--- a/scuttlebutt-rpc/src/main/java/org/apache/tuweni/scuttlebutt/rpc/RPCResponse.java
+++ b/scuttlebutt-rpc/src/main/java/org/apache/tuweni/scuttlebutt/rpc/RPCResponse.java
@@ -19,6 +19,7 @@ import org.apache.tuweni.scuttlebutt.rpc.RPCFlag.BodyType;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
@@ -76,5 +77,10 @@ public class RPCResponse {
   public <T> T asJSON(ObjectMapper objectMapper, Class<T> clazz) throws IOException {
     return objectMapper.readerFor(clazz).readValue(body().toArrayUnsafe());
   }
+
+  public <T> T asJSON(ObjectMapper objectMapper, TypeReference<T> typeReference) throws IOException {
+    return objectMapper.readerFor(typeReference).readValue(body().toArrayUnsafe());
+  }
+
 
 }


### PR DESCRIPTION
This change adds new functionality to the `NetworkService` service for querying peers that the server is connected to, and peers that it has in its gossip table and their connection state.

Additionally, it introduces a new `SocialService` to query the social graph (for follows, followers and friends) and update the instance's display name and view the display name of other users.

*Note*: These methods assume that certain RPC functions are available to call on the instance that is connected to as a client. These RPC functions are exposed by the `ssb-gossip`, `ssb-about` and `ssb-friends` plugins for `ssb-server`, which are used by most popular clients (patchwork, patchbay, manyverse.)