### PR TITLE
Make constructor public for Ed25519KeyPairIdentity.java

### DIFF
--- a/scuttlebutt/src/main/java/org/apache/tuweni/scuttlebutt/Ed25519KeyPairIdentity.java
+++ b/scuttlebutt/src/main/java/org/apache/tuweni/scuttlebutt/Ed25519KeyPairIdentity.java
@@ -26,7 +26,7 @@ final class Ed25519KeyPairIdentity implements Identity {
 
   private final Signature.KeyPair keyPair;
 
-  Ed25519KeyPairIdentity(Signature.KeyPair keyPair) {
+  public Ed25519KeyPairIdentity(Signature.KeyPair keyPair) {
     this.keyPair = keyPair;
   }
 


### PR DESCRIPTION
Cannot make a new Ed25519KeyPairIdentity in Clojure via Java interop without this constructor being explicitly public.