### PR TITLE
Make other constructor in ScuttlebuttLocalDiscoveryService.java public

### DIFF
--- a/scuttlebutt-discovery/src/main/java/org/apache/tuweni/scuttlebutt/discovery/ScuttlebuttLocalDiscoveryService.java
+++ b/scuttlebutt-discovery/src/main/java/org/apache/tuweni/scuttlebutt/discovery/ScuttlebuttLocalDiscoveryService.java
@@ -75,7 +75,7 @@ public class ScuttlebuttLocalDiscoveryService {
   }
 
 
-  ScuttlebuttLocalDiscoveryService(
+  public ScuttlebuttLocalDiscoveryService(
       Vertx vertx,
       Logger logger,
       int listenPort,

--- a/scuttlebutt-discovery/src/main/java/org/apache/tuweni/scuttlebutt/discovery/ScuttlebuttLocalDiscoveryService.java
+++ b/scuttlebutt-discovery/src/main/java/org/apache/tuweni/scuttlebutt/discovery/ScuttlebuttLocalDiscoveryService.java
@@ -75,6 +75,16 @@ public class ScuttlebuttLocalDiscoveryService {
   }
 
 
+  /**
+   * Constructor with option to not validate that multicastAddress is in fact a multicast address.
+   *
+   * @param vertx Vert.x instance used to create the UDP socket
+   * @param logger the logger used to log events and errors
+   * @param listenPort the port to bind the UDP socket to
+   * @param listenNetworkInterface the network interface to bind the UDP socket to
+   * @param multicastAddress the address to broadcast multicast packets to
+   * @param validateMulticast check whether or not multicastAddress is actually a multicast address
+   */
   public ScuttlebuttLocalDiscoveryService(
       Vertx vertx,
       Logger logger,


### PR DESCRIPTION
Again, having a public constructor explicitly marked as "public" is necessary in order to access it via Clojure Java interop