### PR TITLE
Upgrade codec dependency

### DIFF
--- a/dependency-versions.gradle
+++ b/dependency-versions.gradle
@@ -12,7 +12,7 @@
  */
 dependencyManagement {
   dependencies {
-    dependency('commons-codec:commons-codec:1.12')
+    dependency('commons-codec:commons-codec:1.14')
     dependency('com.fasterxml.jackson.core:jackson-databind:2.9.5')
     dependency('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.8')
     dependency('com.github.jnr:jnr-ffi:2.1.9')


### PR DESCRIPTION
## PR description
commons-codec 1.12 has a minor information exposure vulnerability that is making Snyk complain.  (https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518) Upgrade it to the latest version.

<!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
 The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
 the License.  You may obtain a copy of the License at

      http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-->