### PR TITLE
Performance - Faster UInt256/Bytes32 conversions

### DIFF
--- a/units/src/main/java/org/apache/tuweni/units/bigints/UInt256.java
+++ b/units/src/main/java/org/apache/tuweni/units/bigints/UInt256.java
@@ -17,7 +17,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.MutableBytes;
-import org.apache.tuweni.bytes.MutableBytes32;
 
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -98,8 +97,22 @@ public final class UInt256 implements UInt256Value<UInt256> {
    * @return A {@link UInt256} containing the specified value.
    * @throws IllegalArgumentException if {@code bytes.size() &gt; 32}.
    */
-  public static UInt256 fromBytes(Bytes bytes) {
-    return new UInt256(Bytes32.leftPad(bytes));
+  public static UInt256 fromBytes(final Bytes bytes) {
+    if (bytes instanceof Bytes32) {
+      final byte[] array = bytes.toArrayUnsafe();
+      return new UInt256(
+          new int[] {
+              ((int) array[0] << 24) | ((int) array[1] << 16) | ((int) array[2] << 8) | ((int) array[3]),
+              ((int) array[4] << 24) | ((int) array[5] << 16) | ((int) array[6] << 8) | ((int) array[7]),
+              ((int) array[8] << 24) | ((int) array[9] << 16) | ((int) array[10] << 8) | ((int) array[11]),
+              ((int) array[12] << 24) | ((int) array[13] << 16) | ((int) array[14] << 8) | ((int) array[15]),
+              ((int) array[16] << 24) | ((int) array[17] << 16) | ((int) array[18] << 8) | ((int) array[19]),
+              ((int) array[20] << 24) | ((int) array[21] << 16) | ((int) array[22] << 8) | ((int) array[23]),
+              ((int) array[24] << 24) | ((int) array[25] << 16) | ((int) array[26] << 8) | ((int) array[27]),
+              ((int) array[28] << 24) | ((int) array[29] << 16) | ((int) array[30] << 8) | ((int) array[31])});
+    } else {
+      return new UInt256(Bytes32.leftPad(bytes));
+    }
   }
 
   /**
@@ -743,11 +756,40 @@ public final class UInt256 implements UInt256Value<UInt256> {
 
   @Override
   public Bytes32 toBytes() {
-    MutableBytes32 bytes = MutableBytes32.create();
-    for (int i = 0, j = 0; i < INTS_SIZE; ++i, j += 4) {
-      bytes.setInt(j, this.ints[i]);
-    }
-    return bytes;
+    return Bytes32.wrap(
+        new byte[] {
+            (byte) (ints[0] >> 24),
+            (byte) (ints[0] >> 16),
+            (byte) (ints[0] >> 8),
+            (byte) (ints[0]),
+            (byte) (ints[1] >> 24),
+            (byte) (ints[1] >> 16),
+            (byte) (ints[1] >> 8),
+            (byte) (ints[1]),
+            (byte) (ints[2] >> 24),
+            (byte) (ints[2] >> 16),
+            (byte) (ints[2] >> 8),
+            (byte) (ints[2]),
+            (byte) (ints[3] >> 24),
+            (byte) (ints[3] >> 16),
+            (byte) (ints[3] >> 8),
+            (byte) (ints[3]),
+            (byte) (ints[4] >> 24),
+            (byte) (ints[4] >> 16),
+            (byte) (ints[4] >> 8),
+            (byte) (ints[4]),
+            (byte) (ints[5] >> 24),
+            (byte) (ints[5] >> 16),
+            (byte) (ints[5] >> 8),
+            (byte) (ints[5]),
+            (byte) (ints[6] >> 24),
+            (byte) (ints[6] >> 16),
+            (byte) (ints[6] >> 8),
+            (byte) (ints[6]),
+            (byte) (ints[7] >> 24),
+            (byte) (ints[7] >> 16),
+            (byte) (ints[7] >> 8),
+            (byte) (ints[7])});
   }
 
   @Override

--- a/units/src/test/java/org/apache/tuweni/units/bigints/UInt256Test.java
+++ b/units/src/test/java/org/apache/tuweni/units/bigints/UInt256Test.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 
 import java.math.BigInteger;
 import java.util.stream.Stream;
@@ -881,6 +882,30 @@ class UInt256Test {
         Arguments.of(
             hv("0x0400000000000000000000000000000000000000000000000000f100000000ab"),
             Bytes.fromHexString("0x0400000000000000000000000000000000000000000000000000f100000000ab")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("fromBytesProvider")
+  void fromBytesTest(Bytes value, UInt256 expected, boolean isBytes32) {
+    assertEquals(expected, UInt256.fromBytes(value));
+    assertEquals(isBytes32, value instanceof Bytes32);
+  }
+
+  private static Stream<Arguments> fromBytesProvider() {
+    String onesString = "11111111111111111111111111111111";
+    String twosString = "22222222222222222222222222222222";
+    Bytes onesBytes = Bytes.fromHexString(onesString);
+    Bytes twosBytes = Bytes.fromHexString(twosString);
+    Bytes onetwoBytes = Bytes.fromHexString(onesString + twosString);
+    return Stream.of(
+        // Mutable Bytes
+        Arguments.of(Bytes.concatenate(onesBytes), hv(onesString), false),
+        Arguments.of(Bytes.concatenate(onesBytes, twosBytes), hv(onesString + twosString), true),
+        // Array Wrapping Bytes
+        Arguments.of(Bytes.fromHexString(onesString), hv(onesString), false),
+        Arguments.of(Bytes.fromHexString(onesString + twosString), hv(onesString + twosString), true),
+        // Delegating Bytes32
+        Arguments.of(Bytes32.wrap(onetwoBytes), hv(onesString + twosString), true));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Hyperledger Besu has identified that converting between Bytes32 and
UInt256 is a performance bottleneck. In particular the current paths
force a large number of calls to org.apache.tuweni.bytes.Bytes::get and
org.apache.tuweni.bytes.Bytes::getInt, both megamorophic interface
methods that Hotspot cannot easily optimize.

The performance change is to go to straight primitive manipulation for
hot cases. This resulted in a 75% speedup in one ad-hoc benchmark
modeling a EVM Transaction execution.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>