### PR TITLE
Prevent signed ints smearing int UInt256

### DIFF
--- a/units/src/main/java/org/apache/tuweni/units/bigints/UInt256.java
+++ b/units/src/main/java/org/apache/tuweni/units/bigints/UInt256.java
@@ -102,14 +102,38 @@ public final class UInt256 implements UInt256Value<UInt256> {
       final byte[] array = bytes.toArrayUnsafe();
       return new UInt256(
           new int[] {
-              ((int) array[0] << 24) | ((int) array[1] << 16) | ((int) array[2] << 8) | ((int) array[3]),
-              ((int) array[4] << 24) | ((int) array[5] << 16) | ((int) array[6] << 8) | ((int) array[7]),
-              ((int) array[8] << 24) | ((int) array[9] << 16) | ((int) array[10] << 8) | ((int) array[11]),
-              ((int) array[12] << 24) | ((int) array[13] << 16) | ((int) array[14] << 8) | ((int) array[15]),
-              ((int) array[16] << 24) | ((int) array[17] << 16) | ((int) array[18] << 8) | ((int) array[19]),
-              ((int) array[20] << 24) | ((int) array[21] << 16) | ((int) array[22] << 8) | ((int) array[23]),
-              ((int) array[24] << 24) | ((int) array[25] << 16) | ((int) array[26] << 8) | ((int) array[27]),
-              ((int) array[28] << 24) | ((int) array[29] << 16) | ((int) array[30] << 8) | ((int) array[31])});
+              (Byte.toUnsignedInt(array[0])) << 24
+                  | (Byte.toUnsignedInt(array[1]) << 16)
+                  | (Byte.toUnsignedInt(array[2]) << 8)
+                  | (Byte.toUnsignedInt(array[3])),
+              (Byte.toUnsignedInt(array[4]) << 24)
+                  | (Byte.toUnsignedInt(array[5]) << 16)
+                  | (Byte.toUnsignedInt(array[6]) << 8)
+                  | (Byte.toUnsignedInt(array[7])),
+              (Byte.toUnsignedInt(array[8]) << 24)
+                  | (Byte.toUnsignedInt(array[9]) << 16)
+                  | (Byte.toUnsignedInt(array[10]) << 8)
+                  | (Byte.toUnsignedInt(array[11])),
+              (Byte.toUnsignedInt(array[12]) << 24)
+                  | (Byte.toUnsignedInt(array[13]) << 16)
+                  | (Byte.toUnsignedInt(array[14]) << 8)
+                  | (Byte.toUnsignedInt(array[15])),
+              (Byte.toUnsignedInt(array[16]) << 24)
+                  | (Byte.toUnsignedInt(array[17]) << 16)
+                  | (Byte.toUnsignedInt(array[18]) << 8)
+                  | (Byte.toUnsignedInt(array[19])),
+              (Byte.toUnsignedInt(array[20]) << 24)
+                  | (Byte.toUnsignedInt(array[21]) << 16)
+                  | (Byte.toUnsignedInt(array[22]) << 8)
+                  | (Byte.toUnsignedInt(array[23])),
+              (Byte.toUnsignedInt(array[24]) << 24)
+                  | (Byte.toUnsignedInt(array[25]) << 16)
+                  | (Byte.toUnsignedInt(array[26]) << 8)
+                  | (Byte.toUnsignedInt(array[27])),
+              (Byte.toUnsignedInt(array[28]) << 24)
+                  | (Byte.toUnsignedInt(array[29]) << 16)
+                  | (Byte.toUnsignedInt(array[30]) << 8)
+                  | (Byte.toUnsignedInt(array[31]))});
     } else {
       return new UInt256(Bytes32.leftPad(bytes));
     }
@@ -756,40 +780,41 @@ public final class UInt256 implements UInt256Value<UInt256> {
 
   @Override
   public Bytes32 toBytes() {
-    return Bytes32.wrap(
-        new byte[] {
-            (byte) (ints[0] >> 24),
-            (byte) (ints[0] >> 16),
-            (byte) (ints[0] >> 8),
-            (byte) (ints[0]),
-            (byte) (ints[1] >> 24),
-            (byte) (ints[1] >> 16),
-            (byte) (ints[1] >> 8),
-            (byte) (ints[1]),
-            (byte) (ints[2] >> 24),
-            (byte) (ints[2] >> 16),
-            (byte) (ints[2] >> 8),
-            (byte) (ints[2]),
-            (byte) (ints[3] >> 24),
-            (byte) (ints[3] >> 16),
-            (byte) (ints[3] >> 8),
-            (byte) (ints[3]),
-            (byte) (ints[4] >> 24),
-            (byte) (ints[4] >> 16),
-            (byte) (ints[4] >> 8),
-            (byte) (ints[4]),
-            (byte) (ints[5] >> 24),
-            (byte) (ints[5] >> 16),
-            (byte) (ints[5] >> 8),
-            (byte) (ints[5]),
-            (byte) (ints[6] >> 24),
-            (byte) (ints[6] >> 16),
-            (byte) (ints[6] >> 8),
-            (byte) (ints[6]),
-            (byte) (ints[7] >> 24),
-            (byte) (ints[7] >> 16),
-            (byte) (ints[7] >> 8),
-            (byte) (ints[7])});
+    return Bytes32
+        .wrap(
+            new byte[] {
+                (byte) (ints[0] >> 24),
+                (byte) (ints[0] >> 16),
+                (byte) (ints[0] >> 8),
+                (byte) (ints[0]),
+                (byte) (ints[1] >> 24),
+                (byte) (ints[1] >> 16),
+                (byte) (ints[1] >> 8),
+                (byte) (ints[1]),
+                (byte) (ints[2] >> 24),
+                (byte) (ints[2] >> 16),
+                (byte) (ints[2] >> 8),
+                (byte) (ints[2]),
+                (byte) (ints[3] >> 24),
+                (byte) (ints[3] >> 16),
+                (byte) (ints[3] >> 8),
+                (byte) (ints[3]),
+                (byte) (ints[4] >> 24),
+                (byte) (ints[4] >> 16),
+                (byte) (ints[4] >> 8),
+                (byte) (ints[4]),
+                (byte) (ints[5] >> 24),
+                (byte) (ints[5] >> 16),
+                (byte) (ints[5] >> 8),
+                (byte) (ints[5]),
+                (byte) (ints[6] >> 24),
+                (byte) (ints[6] >> 16),
+                (byte) (ints[6] >> 8),
+                (byte) (ints[6]),
+                (byte) (ints[7] >> 24),
+                (byte) (ints[7] >> 16),
+                (byte) (ints[7] >> 8),
+                (byte) (ints[7])});
   }
 
   @Override

--- a/units/src/test/java/org/apache/tuweni/units/bigints/UInt256Test.java
+++ b/units/src/test/java/org/apache/tuweni/units/bigints/UInt256Test.java
@@ -960,6 +960,7 @@ class UInt256Test {
   @ParameterizedTest
   @MethodSource("fromBytesProvider")
   void fromBytesTest(Bytes value, UInt256 expected, boolean isBytes32) {
+    assertEquals(expected.toBytes(), UInt256.fromBytes(value).toBytes());
     assertEquals(expected, UInt256.fromBytes(value));
     assertEquals(isBytes32, value instanceof Bytes32);
   }
@@ -967,18 +968,27 @@ class UInt256Test {
   private static Stream<Arguments> fromBytesProvider() {
     String onesString = "11111111111111111111111111111111";
     String twosString = "22222222222222222222222222222222";
+    String eString = "e000000000e000000000e000000000e0";
     Bytes onesBytes = Bytes.fromHexString(onesString);
     Bytes twosBytes = Bytes.fromHexString(twosString);
+    Bytes eBytes = Bytes.fromHexString(eString);
     Bytes onetwoBytes = Bytes.fromHexString(onesString + twosString);
-    return Stream.of(
-        // Mutable Bytes
-        Arguments.of(Bytes.concatenate(onesBytes), hv(onesString), false),
-        Arguments.of(Bytes.concatenate(onesBytes, twosBytes), hv(onesString + twosString), true),
-        // Array Wrapping Bytes
-        Arguments.of(Bytes.fromHexString(onesString), hv(onesString), false),
-        Arguments.of(Bytes.fromHexString(onesString + twosString), hv(onesString + twosString), true),
-        // Delegating Bytes32
-        Arguments.of(Bytes32.wrap(onetwoBytes), hv(onesString + twosString), true));
+    Bytes oneeBytes = Bytes.fromHexString(onesString + eString);
+    return Stream
+        .of(
+            // Mutable Bytes
+            Arguments.of(Bytes.concatenate(onesBytes), hv(onesString), false),
+            Arguments.of(Bytes.concatenate(eBytes), hv(eString), false),
+            Arguments.of(Bytes.concatenate(onesBytes, twosBytes), hv(onesString + twosString), true),
+            Arguments.of(Bytes.concatenate(onesBytes, eBytes), hv(onesString + eString), true),
+            // Array Wrapping Bytes
+            Arguments.of(Bytes.fromHexString(onesString), hv(onesString), false),
+            Arguments.of(Bytes.fromHexString(eString), hv(eString), false),
+            Arguments.of(Bytes.fromHexString(onesString + twosString), hv(onesString + twosString), true),
+            Arguments.of(Bytes.fromHexString(onesString + eString), hv(onesString + eString), true),
+            // Delegating Bytes32
+            Arguments.of(Bytes32.wrap(onetwoBytes), hv(onesString + twosString), true),
+            Arguments.of(Bytes32.wrap(oneeBytes), hv(onesString + eString), true));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
When using the optimized byte32 path the high bit for the signed bytes
get smeared when they are cast.  Also add tests that will fail when such
smearing occurs.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

