### PR TITLE
Fix Windows Tests

### DIFF
--- a/hobbits/src/integrationTest/kotlin/org/apache/tuweni/hobbits/InteractionTest.kt
+++ b/hobbits/src/integrationTest/kotlin/org/apache/tuweni/hobbits/InteractionTest.kt
@@ -177,11 +177,11 @@ class UDPTest {
     val client2 = HobbitsTransport(vertx)
 
     runBlocking {
-      client1.createUDPEndpoint("foo", port = 15000, handler = ref::set)
+      client1.createUDPEndpoint("foo", "localhost", 15000, ref::set)
       client1.start()
       client2.start()
       client2.sendMessage(Message(protocol = Protocol.PING, body = Bytes.fromHexString("deadbeef"),
-        headers = Bytes.random(16)), Transport.UDP, "0.0.0.0", 15000)
+        headers = Bytes.random(16)), Transport.UDP, "localhost", 15000)
     }
     Thread.sleep(200)
     assertEquals(Bytes.fromHexString("deadbeef"), ref.get().body)
@@ -196,20 +196,20 @@ class UDPTest {
     val client1 = HobbitsTransport(vertx)
     val client2 = HobbitsTransport(vertx)
     runBlocking {
-      client1.createUDPEndpoint("foo", port = 16000, handler = ref::set)
-      client1.createUDPEndpoint("bar", port = 16001, handler = ref2::set)
+      client1.createUDPEndpoint("foo", "localhost", 16000, ref::set)
+      client1.createUDPEndpoint("bar", "localhost", 16001, ref2::set)
       client1.start()
       client2.start()
       client2.sendMessage(
         Message(protocol = Protocol.PING, body = Bytes.fromHexString("deadbeef"), headers = Bytes.random(16)),
         Transport.UDP,
-        "0.0.0.0",
+        "localhost",
         16000
       )
       client2.sendMessage(
         Message(protocol = Protocol.PING, body = Bytes.fromHexString("deadbeef"), headers = Bytes.random(16)),
         Transport.UDP,
-        "0.0.0.0",
+        "localhost",
         16001
       )
     }

--- a/hobbits/src/integrationTest/kotlin/org/apache/tuweni/hobbits/RelayerTest.kt
+++ b/hobbits/src/integrationTest/kotlin/org/apache/tuweni/hobbits/RelayerTest.kt
@@ -84,7 +84,7 @@ class RelayerTest {
     val ref = AtomicReference<Message>()
     val client1 = HobbitsTransport(vertx)
     val client2 = HobbitsTransport(vertx)
-    val relayer = Relayer(vertx, "udp://localhost:12000", "udp://0.0.0.0:10000", { })
+    val relayer = Relayer(vertx, "udp://localhost:12000", "udp://localhost:10000", { })
     runBlocking {
       client1.createUDPEndpoint("foo", port = 10000, handler = ref::set)
       client1.start()

--- a/io/src/test/java/org/apache/tuweni/io/ResourcesTest.java
+++ b/io/src/test/java/org/apache/tuweni/io/ResourcesTest.java
@@ -90,8 +90,8 @@ class ResourcesTest {
 
     URLClassLoader classLoader = new URLClassLoader(
         new URL[] {
-            new URL("file:" + folder.toString() + "/"),
-            new URL("file:" + folder.resolve("resourceresolvertest.jar").toString())});
+            folder.toUri().toURL(),
+            folder.resolve("resourceresolvertest.jar").toUri().toURL()});
     List<URL> all =
         Resources.find(classLoader, "/org/apache/tuweni/io/file/resourceresolver/**").collect(Collectors.toList());
 


### PR DESCRIPTION
Fix two issues breaking windows tests:
* Explicitly make hobbits UPD tests bind to 127.0.0.1 instead of 0.0.0.0.
  Windows does not easily support binding to multiple interfaes for listening.
* Rely on java native URL creation for file resource tests.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

## Fixed Issue(s)
fixes #81 