### PR TITLE
Fix escape on JsonSerializer of toml

### DIFF
--- a/toml/src/main/java/org/apache/tuweni/toml/JsonSerializer.java
+++ b/toml/src/main/java/org/apache/tuweni/toml/JsonSerializer.java
@@ -134,8 +134,8 @@ final class JsonSerializer {
     StringBuilder out = new StringBuilder(text.length());
     for (int i = 0; i < text.length(); i++) {
       char ch = text.charAt(i);
-      if (ch == '\'') {
-        out.append("\\'");
+      if (ch == '\"') {
+        out.append("\\\"");
         continue;
       }
       if (ch >= 0x20) {

--- a/toml/src/test/java/org/apache/tuweni/toml/MutableTomlTableTest.java
+++ b/toml/src/test/java/org/apache/tuweni/toml/MutableTomlTableTest.java
@@ -192,4 +192,26 @@ class MutableTomlTableTest {
         + "}\n";
     assertEquals(expected.replace("\n", System.lineSeparator()), table.toJson());
   }
+
+  @Test
+  void shouldSerializeToJSONForEscapeCharacter() {
+    MutableTomlTable table = new MutableTomlTable();
+    table.set("foo", "one'two", positionAt(1, 1));
+    table.set("bar", "hello\"there", positionAt(2, 1));
+    table.set("buz", "good\tbye", positionAt(3, 1));
+    table.set("bug", "alpha\bbeta", positionAt(4, 1));
+    table.set("egg", "bread\rham", positionAt(5, 1));
+    table.set("pet", "dog\fcat", positionAt(6, 1));
+    table.set("red", "black\nwhite", positionAt(7, 1));
+    String expected = "{\n"
+        + "  \"bar\" : \"hello\\\"there\",\n"
+        + "  \"bug\" : \"alpha\\bbeta\",\n"
+        + "  \"buz\" : \"good\\tbye\",\n"
+        + "  \"egg\" : \"bread\\rham\",\n"
+        + "  \"foo\" : \"one'two\",\n"
+        + "  \"pet\" : \"dog\\fcat\",\n"
+        + "  \"red\" : \"black\\nwhite\"\n"
+        + "}\n";
+    assertEquals(expected.replace("\n", System.lineSeparator()), table.toJson());
+  }
 }


### PR DESCRIPTION
Thank you for creating a great library.

## PR description
This PR fixes a bug which is a toml feature can't convert toml object to Json strings by `toJson()` method in some cases. 

This JsonSerializer escapes  `'`. But, It does not need for Json.
Also, the JsonSerializer does not escape `"`. It should be escaped for Json.