### PR TITLE
Windows Testing Fixes

### DIFF
--- a/concurrent-coroutines/src/test/kotlin/org/apache/tuweni/concurrent/coroutines/RetryableTest.kt
+++ b/concurrent-coroutines/src/test/kotlin/org/apache/tuweni/concurrent/coroutines/RetryableTest.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.lang.RuntimeException
@@ -61,7 +62,7 @@ internal class RetryableTest {
       "done $i"
     }
     assertEquals("done 4", result)
-    assertEquals(6, attempts)
+    assertTrue(attempts > 4)
   }
 
   @Test

--- a/io/src/main/java/org/apache/tuweni/io/file/Files.java
+++ b/io/src/main/java/org/apache/tuweni/io/file/Files.java
@@ -72,13 +72,21 @@ public final class Files {
     walkFileTree(directory, new SimpleFileVisitor<>() {
       @Override
       public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        delete(file);
+        try {
+          delete(file);
+        } catch (IOException ioe) {
+          file.toFile().deleteOnExit();
+        }
         return FileVisitResult.CONTINUE;
       }
 
       @Override
       public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-        delete(dir);
+        try {
+          delete(dir);
+        } catch (IOException ioe) {
+          dir.toFile().deleteOnExit();
+        }
         return FileVisitResult.CONTINUE;
       }
     });

--- a/kv/src/test/kotlin/org/apache/tuweni/kv/KeyValueStoreSpec.kt
+++ b/kv/src/test/kotlin/org/apache/tuweni/kv/KeyValueStoreSpec.kt
@@ -22,6 +22,7 @@ import com.winterbe.expekt.should
 import kotlinx.coroutines.runBlocking
 import org.apache.tuweni.bytes.Bytes
 import org.apache.tuweni.io.Base64
+import org.apache.tuweni.io.file.Files as TwFiles
 import org.apache.tuweni.kv.Vars.bar
 import org.apache.tuweni.kv.Vars.foo
 import org.apache.tuweni.kv.Vars.foobar
@@ -223,7 +224,7 @@ object MapDBKeyValueStoreSpec : Spek({
 
     afterGroup {
       kv.close()
-      MoreFiles.deleteRecursively(testDir, RecursiveDeleteOption.ALLOW_INSECURE)
+      TwFiles.deleteRecursively(testDir)
     }
   }
 })


### PR DESCRIPTION
Two general windows fixes:
* When deleting a file, sometimes windows insists it is in use.
  In that case mark it as deleteOnExit, it's the best we can do.
* Sub-second delays and thread switching is not as reliable in windows.
  Change an assert to accept a range of delays.

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>

