### PR TITLE
Make build more resiliant

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 
 plugins {
   id 'com.diffplug.gradle.spotless' version '3.28.1'
-  id 'net.ltgt.errorprone' version '0.6'
+  id 'net.ltgt.errorprone' version '1.2.1'
   id 'io.spring.dependency-management' version '1.0.6.RELEASE'
   id 'com.github.hierynomus.license' version '0.15.0'
   id 'org.gradle.crypto.checksum' version '1.1.0'
@@ -39,17 +39,6 @@ plugins {
 }
 
 description = 'A set of libraries and other tools to aid development of blockchain and other decentralized software in Java and other JVM languages'
-
-//////
-// Sanity checks
-if (!file("${rootDir}/eth-reference-tests/src/test/resources/eth2.0-tests/README.md").exists()) {
-  throw new GradleException("eth-reference-tests/src/test/resources/eth2.0-tests/README.md missing: please clone submodules (git submodule update --init --recursive)")
-}
-
-if (!file("${rootDir}/eth2-reference-tests/src/test/resources").exists()) {
-  throw new GradleException("${rootDir}/eth2-reference-tests/src/test/resources missing: please clone submodules (git submodule update --init --recursive)")
-}
-
 
 //////
 // Version numbering
@@ -124,6 +113,7 @@ if (file('.git').exists()) {
         '.github/pull_request_template.md',
         'devp2p-eth/src/test/resources/mainnet.json',
         'eth/src/test/resources/mainnet.json',
+        'eth-client/src/main/resources/mainnet.json',
         'eth/src/test/resources/missing-difficulty.json',
         'eth/src/test/resources/missing-nonce.json',
         'eth/src/test/resources/valid-genesis.json'
@@ -250,7 +240,7 @@ allprojects {
   sourceCompatibility = '1.11'
   targetCompatibility = '1.11'
 
-  jacoco { toolVersion = '0.8.2' }
+  jacoco { toolVersion = '0.8.5' }
 
   dependencies {
     errorprone 'com.google.errorprone:error_prone_core'
@@ -277,9 +267,20 @@ allprojects {
     ]
 
     options.errorprone {
-      excludedPaths '.*/generated-src/.*'
+      excludedPaths = '.*/generated-src/.*'
       check('FutureReturnValueIgnored', CheckSeverity.OFF)
       check('UnnecessaryParentheses', CheckSeverity.OFF)
+
+      // This check is broken in Java 12.  See https://github.com/google/error-prone/issues/1257
+      if (JavaVersion.current() == JavaVersion.VERSION_12) {
+        check('Finally', CheckSeverity.OFF)
+      }
+
+      // This check is broken after Java 12.  See https://github.com/google/error-prone/issues/1352
+      if (JavaVersion.current() > JavaVersion.VERSION_12) {
+        check('TypeParameterUnusedInFormals', CheckSeverity.OFF)
+      }
+
       disableWarningsInGeneratedCode = true
     }
   }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -86,12 +86,10 @@ distributions {
       }
       rootProject.subprojects.each { s ->
         into(s.name) {
-          if (project != s) {
-            from s.sourcesJar.outputs.files.collect {
-              zipTree(it)
-            }
-          }
           from s.projectDir.toPath().resolve("build.gradle")
+        }
+        into("${s.name}/src/main") {
+          from s.projectDir.toPath().resolve("src/main")
         }
       }
     }

--- a/eth-client/src/main/resources/logback.xml
+++ b/eth-client/src/main/resources/logback.xml
@@ -1,3 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements. See the NOTICE
+ file distributed with this work for additional information regarding copyright ownership. The ASF licenses this file
+ to You under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ License. You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations under the License.
+-->
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/eth-reference-tests/build.gradle
+++ b/eth-reference-tests/build.gradle
@@ -27,3 +27,13 @@ dependencies {
 
   testRuntime 'org.junit.jupiter:junit-jupiter-engine'
 }
+
+def submodulePresent = file("${projectDir}/eth-reference-tests/src/test/resources/eth2.0-tests/README.md").exists()
+def testsPresent = file("${projectDir}/src/test/java/org/apache/tuweni/eth/reference/BlockRLPTestSuite.java").exists()
+if (!submodulePresent && testsPresent) {
+  println """${projectDir}/src/test/resources/eth2.0-tests/README.md missing: please clone submodules (git submodule update --init --recursive)
+Reference test validations will not be performed.
+"""
+}
+
+test.enabled = submodulePresent

--- a/eth2-reference-tests/build.gradle
+++ b/eth2-reference-tests/build.gradle
@@ -23,3 +23,13 @@ dependencies {
 
   testRuntime 'org.junit.jupiter:junit-jupiter-engine'
 }
+
+def submodulePresent = file("${projectDir}/src/test/resources/README.md").exists()
+def testsPresent = file("${projectDir}/src/test/java/").exists()
+if (!submodulePresent && testsPresent) {
+  println """${projectDir}/src/test/resources missing: please clone submodules (git submodule update --init --recursive)
+Reference test validations will not be performed.
+"""
+}
+
+test.enabled = submodulePresent

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -135,13 +135,16 @@ downloadLicenses {
   ]
 
   licenses = [
-    (group('tuweni')): apache2,
-    (group('org.jboss.spec.javax.transaction')): cddl1,
-    (group('org.rocksdb')): apache2,
+    // Logback is dual licensed under EPL v1.0 or LGPL v2.1
+    // Explicitly declare that we are using the EPL v1.0 license
+    (group('ch.qos.logback'))   : epl1,
     // https://checkerframework.org/manual/#license
     // The more permissive MIT License applies to code that you might want
     // to include in your own program, such as the annotations and run-time utility classes.
-    (group('org.checkerframework')): mit
+    (group('org.checkerframework')): mit,
+    (group('org.jboss.spec.javax.transaction')): cddl1,
+    (group('org.rocksdb')): apache2,
+    (group('tuweni')): apache2
   ]
 }
 


### PR DESCRIPTION
* upgrade gradle wrapper to 6.3
* upgrade errorprone plugin to 1.2.1
* disable a few errorprone checks based on java version
* upgrade jacoco to 0.8.5
* apply missing license header
* explicitly opt into logback EPL1 license
* make submodule optional
* make src jar buildable

Signed-off-by: Danno Ferrin <danno.ferrin@gmail.com>