### PR TITLE
Add a different NOTICE for binary distrib

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -27,7 +27,6 @@ static def mandatoryFiles(CopySpec spec) {
     from ".."
     include 'DISCLAIMER'
     include 'LICENSE'
-    include 'NOTICE'
   }
   spec.into('licenses') { from '../build/reports/license' }
 }
@@ -55,6 +54,7 @@ asfNexusPassword=
 }
 
 assemble.dependsOn builtGradleProperties
+assemble.dependsOn rootProject.createNotice
 
 distributions {
   main {
@@ -64,6 +64,10 @@ distributions {
       into('') {
         from ".."
         include 'README.md'
+      }
+      into('') {
+        from "../build/reports/notice"
+        include 'NOTICE'
       }
       def libs = []
       def sources = []
@@ -102,6 +106,7 @@ distributions {
       mandatoryFiles(it)
       into('') {
         from ".."
+        include 'NOTICE'
         include 'README.md'
         include 'build.sh'
         include 'build.bat'

--- a/gradle/check-licenses.gradle
+++ b/gradle/check-licenses.gradle
@@ -193,3 +193,29 @@ task checkLicenses {
     }
   }
 }
+
+task createNotice {
+  description "Create a NOTICE file with all dependencies"
+  dependsOn ':downloadLicenses'
+
+  doLast {
+    def xml = new XmlParser().parse("$rootProject.buildDir/reports/license/license-dependency.xml")
+    new File("$rootProject.buildDir/reports/notice").mkdirs()
+    def binaryNoticeFile = new File("$rootProject.buildDir/reports/notice/NOTICE")
+    binaryNoticeFile.write(new File("$rootProject.projectDir/NOTICE").text)
+    def lines = []
+    def maxLength = 0
+    xml.each { license ->
+      license.dependency.each {
+        def line = it.text() + " is bundled with this distribution under " + license.@name + "."
+        maxLength = Math.max(maxLength, line.size())
+        lines << line
+      }
+    }
+    for (line in lines) {
+      binaryNoticeFile.append("=".repeat(maxLength) + "\n")
+      binaryNoticeFile.append(line + "\n")
+    }
+    binaryNoticeFile.append("=".repeat(maxLength) + "\n")
+  }
+}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Add a different NOTICE for binary distribution, including all dependencies with their license.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
