### PR TITLE
Expose the bytes of the public key

### DIFF
--- a/devp2p/src/main/kotlin/org/apache/tuweni/devp2p/EthereumNodeRecord.kt
+++ b/devp2p/src/main/kotlin/org/apache/tuweni/devp2p/EthereumNodeRecord.kt
@@ -264,9 +264,17 @@ class EthereumNodeRecord(
    * @return the ENR public key
    */
   fun publicKey(): SECP256K1.PublicKey {
+    return SECP256K1.PublicKey.fromBytes(publicKeyBytes())
+  }
+
+  /**
+   * The ENR public key entry bytes
+   * @return the ENR public key bytes
+   */
+  fun publicKeyBytes(): Bytes {
     val keyBytes = data["secp256k1"] ?: throw InvalidNodeRecordException("Missing secp256k1 entry")
     val ecPoint = SECP256K1.Parameters.CURVE.getCurve().decodePoint(keyBytes.toArrayUnsafe())
-    return SECP256K1.PublicKey.fromBytes(Bytes.wrap(ecPoint.getEncoded(false)).slice(1))
+    return Bytes.wrap(ecPoint.getEncoded(false)).slice(1)
   }
 
   /**


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Expose the bytes of the public key, so it's no longer required to expose the public key object itself.

Relates to #172 
