### PR TITLE
Expose actual network interface

### DIFF
--- a/les/src/test/kotlin/org/apache/tuweni/les/LESSubProtocolHandlerTest.kt
+++ b/les/src/test/kotlin/org/apache/tuweni/les/LESSubProtocolHandlerTest.kt
@@ -111,6 +111,19 @@ internal class LESSubProtocolHandlerTest {
   )
 
   private class MyRLPxService : RLPxService {
+
+    override fun actualPort(): Int {
+      TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun actualSocketAddress(): InetSocketAddress {
+      TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun advertisedPort(): Int {
+      TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
+
     override fun getClient(subProtocolIdentifier: SubProtocolIdentifier): SubProtocolClient {
       TODO("not implemented")
     }

--- a/rlpx/src/main/java/org/apache/tuweni/rlpx/RLPxService.java
+++ b/rlpx/src/main/java/org/apache/tuweni/rlpx/RLPxService.java
@@ -37,6 +37,29 @@ public interface RLPxService {
    */
   AsyncResult<WireConnection> connectTo(SECP256K1.PublicKey peerPublicKey, InetSocketAddress peerAddress);
 
+  /**
+   * Provides the actual port in use.
+   *
+   * @return the port used by the server
+   * @throws IllegalStateException if the service is not started
+   */
+  int actualPort();
+
+  /**
+   * Provides the actual socket address (network interface and port) in use.
+   *
+   * @return the socket address used by the server
+   * @throws IllegalStateException if the service is not started
+   */
+  InetSocketAddress actualSocketAddress();
+
+  /**
+   * Provides the advertised port.
+   *
+   * @return the port advertised by the server
+   * @throws IllegalStateException if the service is not started
+   */
+  int advertisedPort();
 
   /**
    * Starts the service.

--- a/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
+++ b/rlpx/src/main/java/org/apache/tuweni/rlpx/vertx/VertxRLPxService.java
@@ -249,12 +249,7 @@ public final class VertxRLPxService implements RLPxService {
     }
   }
 
-  /**
-   * Provides the actual port in use.
-   * 
-   * @return the port used by the server
-   * @throws IllegalStateException if the service is not started
-   */
+  @Override
   public int actualPort() {
     if (!started.get()) {
       throw new IllegalStateException("The RLPx service is not active");
@@ -262,12 +257,15 @@ public final class VertxRLPxService implements RLPxService {
     return server.actualPort();
   }
 
-  /**
-   * Provides the advertised port.
-   *
-   * @return the port advertised by the server
-   * @throws IllegalStateException if the service is not started
-   */
+  @Override
+  public InetSocketAddress actualSocketAddress() {
+    if (!started.get()) {
+      throw new IllegalStateException("The RLPx service is not active");
+    }
+    return new InetSocketAddress(networkInterface, server.actualPort());
+  }
+
+  @Override
   public int advertisedPort() {
     if (!started.get()) {
       throw new IllegalStateException("The RLPx service is not active");


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Expose the actual network interface used by the RLPx service, not just the port.

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
