### PR TITLE
Add ability to keep peers alive explicitly

### DIFF
--- a/les/src/test/kotlin/org/apache/tuweni/les/LESSubProtocolHandlerTest.kt
+++ b/les/src/test/kotlin/org/apache/tuweni/les/LESSubProtocolHandlerTest.kt
@@ -64,6 +64,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import java.net.InetSocketAddress
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.Collections.emptyList
 import java.util.UUID
 
 @ExtendWith(BouncyCastleExtension::class, VertxExtension::class, LuceneIndexWriterExtension::class)
@@ -111,6 +112,9 @@ internal class LESSubProtocolHandlerTest {
   )
 
   private class MyRLPxService : RLPxService {
+    override fun addToKeepAliveList(peerPublicKey: SECP256K1.PublicKey) {
+      TODO("not implemented") // To change body of created functions use File | Settings | File Templates.
+    }
 
     override fun actualPort(): Int {
       TODO("not implemented") // To change body of created functions use File | Settings | File Templates.

--- a/rlpx/src/main/java/org/apache/tuweni/rlpx/RLPxService.java
+++ b/rlpx/src/main/java/org/apache/tuweni/rlpx/RLPxService.java
@@ -29,7 +29,7 @@ import java.net.InetSocketAddress;
 public interface RLPxService {
 
   /**
-   * Connects to a remote peer
+   * Connects to a remote peer.
    *
    * @param peerPublicKey the peer public key
    * @param peerAddress the peer host and port
@@ -60,6 +60,13 @@ public interface RLPxService {
    * @throws IllegalStateException if the service is not started
    */
   int advertisedPort();
+
+  /**
+   * Adds a peer public key to the list of peers to keep alive.
+   *
+   * @param peerPublicKey the peer public key
+   */
+  void addToKeepAliveList(SECP256K1.PublicKey peerPublicKey);
 
   /**
    * Starts the service.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Keep peers identified by their public key alive at all times.