### PR TITLE
Make Bytes more performant by caching hashcode

### DIFF
--- a/bytes/src/main/java/org/apache/tuweni/bytes/AbstractBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/AbstractBytes.java
@@ -20,6 +20,8 @@ public abstract class AbstractBytes implements Bytes {
 
   static final char[] HEX_CODE = "0123456789abcdef".toCharArray();
 
+  private Integer hashCode;
+
   /**
    * Compare this value and the provided one for equality.
    *
@@ -48,16 +50,24 @@ public abstract class AbstractBytes implements Bytes {
         return false;
       }
     }
+
     return true;
   }
 
-  @Override
-  public int hashCode() {
+  protected int computeHashcode() {
     int result = 1;
     for (int i = 0; i < size(); i++) {
       result = 31 * result + get(i);
     }
     return result;
+  }
+
+  @Override
+  public int hashCode() {
+    if (this.hashCode == null) {
+      this.hashCode = computeHashcode();
+    }
+    return this.hashCode;
   }
 
   @Override

--- a/bytes/src/main/java/org/apache/tuweni/bytes/ArrayWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/ArrayWrappingBytes.java
@@ -149,35 +149,6 @@ class ArrayWrappingBytes extends AbstractBytes {
     buffer.appendBytes(bytes, offset, length);
   }
 
-  @Override
-  public boolean equals(Object obj) {
-    if (obj == this) {
-      return true;
-    }
-    if (!(obj instanceof ArrayWrappingBytes)) {
-      return super.equals(obj);
-    }
-    ArrayWrappingBytes other = (ArrayWrappingBytes) obj;
-    if (length != other.length) {
-      return false;
-    }
-    for (int i = 0; i < length; ++i) {
-      if (bytes[offset + i] != other.bytes[other.offset + i]) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    int result = 1;
-    int size = size();
-    for (int i = 0; i < size; i++) {
-      result = 31 * result + bytes[offset + i];
-    }
-    return result;
-  }
 
   @Override
   public byte[] toArray() {

--- a/bytes/src/main/java/org/apache/tuweni/bytes/ConcatenatedBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/ConcatenatedBytes.java
@@ -12,6 +12,7 @@
  */
 package org.apache.tuweni.bytes;
 
+
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
@@ -204,5 +205,10 @@ final class ConcatenatedBytes extends AbstractBytes {
       offset += vSize;
       destinationOffset += vSize;
     }
+  }
+
+  @Override
+  public int hashCode() {
+    return computeHashcode();
   }
 }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableArrayWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableArrayWrappingBytes.java
@@ -89,4 +89,9 @@ class MutableArrayWrappingBytes extends ArrayWrappingBytes implements MutableByt
   public Bytes copy() {
     return new ArrayWrappingBytes(toArray());
   }
+
+  @Override
+  public int hashCode() {
+    return computeHashcode();
+  }
 }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableBufferWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableBufferWrappingBytes.java
@@ -73,4 +73,9 @@ final class MutableBufferWrappingBytes extends BufferWrappingBytes implements Mu
   public MutableBytes mutableCopy() {
     return MutableBytes.wrap(toArray());
   }
+
+  @Override
+  public int hashCode() {
+    return computeHashcode();
+  }
 }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufWrappingBytes.java
@@ -78,4 +78,9 @@ final class MutableByteBufWrappingBytes extends ByteBufWrappingBytes implements 
   public MutableBytes mutableCopy() {
     return MutableBytes.wrap(toArray());
   }
+
+  @Override
+  public int hashCode() {
+    return computeHashcode();
+  }
 }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufferWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufferWrappingBytes.java
@@ -67,4 +67,9 @@ public class MutableByteBufferWrappingBytes extends ByteBufferWrappingBytes impl
   public Bytes copy() {
     return new ArrayWrappingBytes(toArray());
   }
+
+  @Override
+  public int hashCode() {
+    return computeHashcode();
+  }
 }

--- a/bytes/src/test/java/org/apache/tuweni/bytes/BytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/BytesTest.java
@@ -178,7 +178,8 @@ class BytesTest extends CommonBytesTests {
 
     // Sanity check for copy(): modify within the wrapped slice and check the copy differs now.
     bytes[2] = 42;
-    assertNotEquals(copy, wrapped);
+    assertEquals("0x2a7f", wrapped.toHexString());
+    assertEquals(Bytes.fromHexString("0x7f7f"), copy);
   }
 
   @Test

--- a/bytes/src/test/java/org/apache/tuweni/bytes/ConcatenatedBytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/ConcatenatedBytesTest.java
@@ -16,6 +16,7 @@ import static org.apache.tuweni.bytes.Bytes.fromHexString;
 import static org.apache.tuweni.bytes.Bytes.wrap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -112,5 +113,14 @@ class ConcatenatedBytesTest {
     MutableBytes dest = MutableBytes.create(32);
     bytes.copyTo(dest, 10);
     assertEquals(Bytes.fromHexString("0x0000000000000000000001234567000000000000000000000000000000000000"), dest);
+  }
+
+  @Test
+  void testHashcodeUpdates() {
+    MutableBytes dest = MutableBytes.create(32);
+    Bytes bytes = wrap(dest, fromHexString("0x4567"));
+    int hashCode = bytes.hashCode();
+    dest.set(1, (byte) 123);
+    assertNotEquals(hashCode, bytes.hashCode());
   }
 }

--- a/bytes/src/test/java/org/apache/tuweni/bytes/GuardedBytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/GuardedBytesTest.java
@@ -178,7 +178,8 @@ class GuardedBytesTest extends CommonBytesTests {
 
     // Sanity check for copy(): modify within the wrapped slice and check the copy differs now.
     bytes[2] = 42;
-    assertNotEquals(copy, wrapped);
+    assertEquals("0x2a7f", wrapped.toHexString());
+    assertEquals(Bytes.fromHexString("0x7f7f"), copy);
   }
 
   @Test

--- a/bytes/src/test/java/org/apache/tuweni/bytes/MutableBytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/MutableBytesTest.java
@@ -13,9 +13,12 @@
 package org.apache.tuweni.bytes;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
 
 import io.netty.buffer.Unpooled;
 import io.vertx.core.buffer.Buffer;
@@ -108,5 +111,37 @@ class MutableBytesTest {
     assertSame(MutableBytes.EMPTY, b);
     b = MutableBytes.wrapByteBuf(Unpooled.buffer(), 4, 0);
     assertSame(MutableBytes.EMPTY, b);
+  }
+
+  @Test
+  void testHashcodeUpdates() {
+    MutableBytes dest = MutableBytes.create(32);
+    int hashCode = dest.hashCode();
+    dest.set(1, (byte) 123);
+    assertNotEquals(hashCode, dest.hashCode());
+  }
+
+  @Test
+  void testHashcodeUpdatesBuffer() {
+    MutableBytes dest = MutableBytes.wrapBuffer(Buffer.buffer(new byte[4]));
+    int hashCode = dest.hashCode();
+    dest.set(1, (byte) 123);
+    assertNotEquals(hashCode, dest.hashCode());
+  }
+
+  @Test
+  void testHashcodeUpdatesByteBuffer() {
+    MutableBytes dest = MutableBytes.wrapByteBuffer(ByteBuffer.wrap(new byte[4]));
+    int hashCode = dest.hashCode();
+    dest.set(1, (byte) 123);
+    assertNotEquals(hashCode, dest.hashCode());
+  }
+
+  @Test
+  void testHashcodeUpdatesByteBuf() {
+    MutableBytes dest = MutableBytes.wrapByteBuf(Unpooled.buffer(4));
+    int hashCode = dest.hashCode();
+    dest.set(1, (byte) 123);
+    assertNotEquals(hashCode, dest.hashCode());
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Use the Bytes hash code to perform equals, and cache it if possible.
