### PR TITLE
rename license folder to license-reports

### DIFF
--- a/dist/NOTICE-binary
+++ b/dist/NOTICE-binary
@@ -29,7 +29,7 @@ This product contains the extensions to Java Collections Framework which has
 been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
 
   * LICENSE:
-    * license/LICENSE.jsr166y.txt (Public Domain)
+    * license-reports/LICENSE.jsr166y.txt (Public Domain)
   * HOMEPAGE:
     * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
     * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
@@ -38,7 +38,7 @@ This product contains a modified version of Robert Harder's Public Domain
 Base64 Encoder and Decoder, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.base64.txt (Public Domain)
+    * license-reports/LICENSE.base64.txt (Public Domain)
   * HOMEPAGE:
     * http://iharder.sourceforge.net/current/java/base64/
 
@@ -46,7 +46,7 @@ This product contains a modified portion of 'Webbit', an event based
 WebSocket and HTTP server, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.webbit.txt (BSD License)
+    * license-reports/LICENSE.webbit.txt (BSD License)
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
 
@@ -54,7 +54,7 @@ This product contains a modified portion of 'SLF4J', a simple logging
 facade for Java, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.slf4j.txt (MIT License)
+    * license-reports/LICENSE.slf4j.txt (MIT License)
   * HOMEPAGE:
     * https://www.slf4j.org/
 
@@ -62,9 +62,9 @@ This product contains a modified portion of 'Apache Harmony', an open source
 Java SE, which can be obtained at:
 
   * NOTICE:
-    * license/NOTICE.harmony.txt
+    * license-reports/NOTICE.harmony.txt
   * LICENSE:
-    * license/LICENSE.harmony.txt (Apache License 2.0)
+    * license-reports/LICENSE.harmony.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://archive.apache.org/dist/harmony/
 
@@ -72,7 +72,7 @@ This product contains a modified portion of 'jbzip2', a Java bzip2 compression
 and decompression library written by Matthew J. Francis. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jbzip2.txt (MIT License)
+    * license-reports/LICENSE.jbzip2.txt (MIT License)
   * HOMEPAGE:
     * https://code.google.com/p/jbzip2/
 
@@ -81,7 +81,7 @@ the suffix array and the Burrows-Wheeler transformed string for any input string
 a constant-size alphabet written by Yuta Mori. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.libdivsufsort.txt (MIT License)
+    * license-reports/LICENSE.libdivsufsort.txt (MIT License)
   * HOMEPAGE:
     * https://github.com/y-256/libdivsufsort
 
@@ -89,7 +89,7 @@ This product contains a modified portion of Nitsan Wakart's 'JCTools', Java Conc
  which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jctools.txt (ASL2 License)
+    * license-reports/LICENSE.jctools.txt (ASL2 License)
   * HOMEPAGE:
     * https://github.com/JCTools/JCTools
 
@@ -97,7 +97,7 @@ This product optionally depends on 'JZlib', a re-implementation of zlib in
 pure Java, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jzlib.txt (BSD style License)
+    * license-reports/LICENSE.jzlib.txt (BSD style License)
   * HOMEPAGE:
     * http://www.jcraft.com/jzlib/
 
@@ -105,7 +105,7 @@ This product optionally depends on 'Compress-LZF', a Java library for encoding a
 decoding data in LZF format, written by Tatu Saloranta. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.compress-lzf.txt (Apache License 2.0)
+    * license-reports/LICENSE.compress-lzf.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/ning/compress
 
@@ -113,7 +113,7 @@ This product optionally depends on 'lz4', a LZ4 Java compression
 and decompression library written by Adrien Grand. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.lz4.txt (Apache License 2.0)
+    * license-reports/LICENSE.lz4.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/jpountz/lz4-java
 
@@ -121,7 +121,7 @@ This product optionally depends on 'lzma-java', a LZMA Java compression
 and decompression library, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.lzma-java.txt (Apache License 2.0)
+    * license-reports/LICENSE.lzma-java.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/jponge/lzma-java
 
@@ -129,7 +129,7 @@ This product contains a modified portion of 'jfastlz', a Java port of FastLZ com
 and decompression library written by William Kinney. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jfastlz.txt (MIT License)
+    * license-reports/LICENSE.jfastlz.txt (MIT License)
   * HOMEPAGE:
     * https://code.google.com/p/jfastlz/
 
@@ -137,7 +137,7 @@ This product contains a modified portion of and optionally depends on 'Protocol 
 interchange format, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
+    * license-reports/LICENSE.protobuf.txt (New BSD License)
   * HOMEPAGE:
     * https://github.com/google/protobuf
 
@@ -146,7 +146,7 @@ a temporary self-signed X.509 certificate when the JVM does not provide the
 equivalent functionality.  It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.bouncycastle.txt (MIT License)
+    * license-reports/LICENSE.bouncycastle.txt (MIT License)
   * HOMEPAGE:
     * https://www.bouncycastle.org/
 
@@ -154,7 +154,7 @@ This product optionally depends on 'Snappy', a compression library produced
 by Google Inc, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.snappy.txt (New BSD License)
+    * license-reports/LICENSE.snappy.txt (New BSD License)
   * HOMEPAGE:
     * https://github.com/google/snappy
 
@@ -162,7 +162,7 @@ This product optionally depends on 'JBoss Marshalling', an alternative Java
 serialization API, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.jboss-marshalling.txt (Apache License 2.0)
+    * license-reports/LICENSE.jboss-marshalling.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/jboss-remoting/jboss-marshalling
 
@@ -170,7 +170,7 @@ This product optionally depends on 'Caliper', Google's micro-
 benchmarking framework, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.caliper.txt (Apache License 2.0)
+    * license-reports/LICENSE.caliper.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/google/caliper
 
@@ -178,7 +178,7 @@ This product optionally depends on 'Apache Commons Logging', a logging
 framework, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.commons-logging.txt (Apache License 2.0)
+    * license-reports/LICENSE.commons-logging.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://commons.apache.org/logging/
 
@@ -186,7 +186,7 @@ This product optionally depends on 'Apache Log4J', a logging framework, which
 can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.log4j.txt (Apache License 2.0)
+    * license-reports/LICENSE.log4j.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://logging.apache.org/log4j/
 
@@ -194,7 +194,7 @@ This product optionally depends on 'Aalto XML', an ultra-high performance
 non-blocking XML processor, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.aalto-xml.txt (Apache License 2.0)
+    * license-reports/LICENSE.aalto-xml.txt (Apache License 2.0)
   * HOMEPAGE:
     * http://wiki.fasterxml.com/AaltoHome
 
@@ -202,7 +202,7 @@ This product contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Twitter. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.hpack.txt (Apache License 2.0)
+    * license-reports/LICENSE.hpack.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/twitter/hpack
 
@@ -210,7 +210,7 @@ This product contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Cory Benfield. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.hyper-hpack.txt (MIT License)
+    * license-reports/LICENSE.hyper-hpack.txt (MIT License)
   * HOMEPAGE:
     * https://github.com/python-hyper/hpack/
 
@@ -218,7 +218,7 @@ This product contains a modified version of 'HPACK', a Java implementation of
 the HTTP/2 HPACK algorithm written by Tatsuhiro Tsujikawa. It can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.nghttp2-hpack.txt (MIT License)
+    * license-reports/LICENSE.nghttp2-hpack.txt (MIT License)
   * HOMEPAGE:
     * https://github.com/nghttp2/nghttp2/
 
@@ -226,7 +226,7 @@ This product contains a modified portion of 'Apache Commons Lang', a Java librar
 provides utilities for the java.lang API, which can be obtained at:
 
   * LICENSE:
-    * license/LICENSE.commons-lang.txt (Apache License 2.0)
+    * license-reports/LICENSE.commons-lang.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://commons.apache.org/proper/commons-lang/
 
@@ -234,7 +234,7 @@ provides utilities for the java.lang API, which can be obtained at:
 This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
 
   * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+    * license-reports/LICENSE.mvn-wrapper.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
@@ -243,7 +243,7 @@ This private header is also used by Apple's open source
  mDNSResponder (https://opensource.apple.com/tarballs/mDNSResponder/).
 
  * LICENSE:
-    * license/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
+    * license-reports/LICENSE.dnsinfo.txt (Apple Public Source License 2.0)
   * HOMEPAGE:
     * https://www.opensource.apple.com/source/configd/configd-453.19/dnsinfo/dnsinfo.h
 -------------------------------------------------------------------------------

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -27,9 +27,9 @@ task createBinaryLicense {
 
   doLast {
     new File("$project.buildDir/license").mkdirs()
-    def binaryNoticeFile = new File("$project.buildDir/license/LICENSE")
-    binaryNoticeFile.write(new File("$rootProject.projectDir/LICENSE").text)
-    binaryNoticeFile.append(new File("$project.projectDir/LICENSE-binary").text)
+    def binaryLicenseFile = new File("$project.buildDir/license/LICENSE")
+    binaryLicenseFile.write(new File("$rootProject.projectDir/LICENSE").text)
+    binaryLicenseFile.append(new File("$project.projectDir/LICENSE-binary").text)
   }
 }
 
@@ -49,7 +49,7 @@ static def mandatoryFiles(CopySpec spec) {
     from ".."
     include 'DISCLAIMER'
   }
-  spec.into('license') { from '../build/reports/license' }
+  spec.into('license-reports') { from '../build/reports/license' }
 }
 
 task builtGradleProperties()  {
@@ -88,7 +88,7 @@ distributions {
         from ".."
         include 'README.md'
       }
-      into('license') {
+      into('license-reports') {
         from "netty-license"
         include "*"
       }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/master/CONTRIBUTING.md -->

## PR description
Case insensitive file systems don't like having to deal with a LICENSE file and license folder. Renaming license to license-reports.

