### PR TITLE
Add dist to build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,4 +13,4 @@
 pushd gradle/docker
 docker build -t tuweni_test -f test.Dockerfile ../..
 popd
-docker run -v `pwd`/build/libs:/home/gradle/build/libs tuweni_test bash -c 'gradle -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=512m" assemble'
+docker run -v `pwd`/build/libs:/home/gradle/build/libs -v `pwd`/dist/build:/home/gradle/dist/build tuweni_test bash -c 'gradle -Dorg.gradle.jvmargs="-Xmx2g -XX:MaxMetaspaceSize=512m" assemble'


### PR DESCRIPTION
## PR description
Add dist build folder to the mounted folders when running build.sh, so folks can get the distributions by following the build.sh script


