### PR TITLE
Pick the eth subprotocol that was negotiated

### DIFF
--- a/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHandler.kt
+++ b/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHandler.kt
@@ -213,10 +213,15 @@ internal class EthHandler(
   override fun handleNewPeerConnection(connection: WireConnection): AsyncCompletion {
     val newPeer = PeerInfo()
     pendingStatus[connection.uri()] = newPeer
+    val ethSubProtocol = connection.agreedSubprotocols().firstOrNull() { it.name() == EthSubprotocol.ETH65.name() }
+    if (ethSubProtocol == null) {
+      newPeer.cancel()
+      return newPeer.ready
+    }
     service.send(
-      EthSubprotocol.ETH64, MessageType.Status.code, connection,
+      ethSubProtocol, MessageType.Status.code, connection,
       StatusMessage(
-        EthSubprotocol.ETH65.version(),
+        ethSubProtocol.version(),
         blockchainInfo.networkID(), blockchainInfo.totalDifficulty(),
         blockchainInfo.bestHash(), blockchainInfo.genesisHash(), blockchainInfo.getLatestForkHash(),
         blockchainInfo.getLatestFork()

--- a/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHandler66.kt
+++ b/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHandler66.kt
@@ -245,13 +245,18 @@ internal class EthHandler66(
   override fun handleNewPeerConnection(connection: WireConnection): AsyncCompletion {
     val newPeer = PeerInfo()
     pendingStatus[connection.uri()] = newPeer
+    val ethSubProtocol = connection.agreedSubprotocols().firstOrNull() { it.name() == EthSubprotocol.ETH65.name() }
+    if (ethSubProtocol == null) {
+      newPeer.cancel()
+      return newPeer.ready
+    }
     service.send(
-      EthSubprotocol.ETH66, MessageType.Status.code, connection,
+      ethSubProtocol, MessageType.Status.code, connection,
       RLP.encodeList {
         it.writeValue(UInt64.random().toBytes())
         it.writeRLP(
           StatusMessage(
-            EthSubprotocol.ETH66.version(),
+            ethSubProtocol.version(),
             blockchainInfo.networkID(), blockchainInfo.totalDifficulty(),
             blockchainInfo.bestHash(), blockchainInfo.genesisHash(), blockchainInfo.getLatestForkHash(),
             blockchainInfo.getLatestFork()

--- a/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHelloHandler.kt
+++ b/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthHelloHandler.kt
@@ -68,10 +68,15 @@ internal class EthHelloHandler(
   override fun handleNewPeerConnection(connection: WireConnection): AsyncCompletion {
     val newPeer = PeerInfo()
     pendingStatus[connection.uri()] = newPeer
+    val ethSubProtocol = connection.agreedSubprotocols().firstOrNull() { it.name() == EthSubprotocol.ETH65.name() }
+    if (ethSubProtocol == null) {
+      newPeer.cancel()
+      return newPeer.ready
+    }
     service.send(
-      EthSubprotocol.ETH64, MessageType.Status.code, connection,
+      ethSubProtocol, MessageType.Status.code, connection,
       StatusMessage(
-        EthSubprotocol.ETH64.version(),
+        ethSubProtocol.version(),
         blockchainInfo.networkID(), blockchainInfo.totalDifficulty(),
         blockchainInfo.bestHash(), blockchainInfo.genesisHash(), blockchainInfo.getLatestForkHash(),
         blockchainInfo.getLatestFork()


### PR DESCRIPTION
## PR description
An issue reported by the network crawler: you cannot assume that the protocol negotiated is eth/64, you have to pick whichever is used by the connection.
