### PR TITLE
clean up docker apt cache

### DIFF
--- a/dist/docker/tuweni.Dockerfile
+++ b/dist/docker/tuweni.Dockerfile
@@ -11,7 +11,9 @@
 
 FROM openjdk:11.0.3-jre-stretch
 
-RUN apt-get update && apt-get install -y libsodium-dev
+RUN apt-get update \
+ && apt-get install -y libsodium-dev \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY build/distributions/tuweni-bin-*.tgz /usr/tuweni.tgz
 RUN cd /usr \


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description
Remove the apt-cache when building with Docker.
