### PR TITLE
Resolve libsodium performance degradation

### DIFF
--- a/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
+++ b/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
@@ -12,8 +12,6 @@
  */
 package org.apache.tuweni.crypto;
 
-import static java.util.Objects.requireNonNull;
-
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.sodium.SHA256Hash;
@@ -22,6 +20,8 @@ import org.apache.tuweni.crypto.sodium.Sodium;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Various utilities for providing hashes (digests) of arbitrary data.
  *
@@ -29,7 +29,7 @@ import java.security.NoSuchAlgorithmException;
  * https://www.bouncycastle.org/wiki/display/JA1/Provider+Installation for detail.
  */
 public final class Hash {
-  static boolean USE_SODIUM = Boolean.parseBoolean(System.getProperty("org.apahce.tuweni.crypto.useSodium", "true"));
+  static boolean USE_SODIUM = Boolean.parseBoolean(System.getProperty("org.apache.tuweni.crypto.useSodium", "true"));
 
   private Hash() {}
 

--- a/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
+++ b/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
@@ -29,7 +29,7 @@ import java.security.NoSuchAlgorithmException;
  * https://www.bouncycastle.org/wiki/display/JA1/Provider+Installation for detail.
  */
 public final class Hash {
-  static boolean USE_SODIUM = true;
+  static boolean USE_SODIUM = Boolean.parseBoolean(System.getProperty("org.apahce.tuweni.crypto.useSodium", "true"));
 
   private Hash() {}
 
@@ -83,7 +83,7 @@ public final class Hash {
    * @return A digest.
    */
   public static byte[] sha2_256(byte[] input) {
-    if (USE_SODIUM && Sodium.isAvailable()) {
+    if (isSodiumAvailable()) {
       SHA256Hash.Input shaInput = SHA256Hash.Input.fromBytes(input);
       try {
         SHA256Hash.Hash result = SHA256Hash.hash(shaInput);
@@ -110,7 +110,7 @@ public final class Hash {
    * @return A digest.
    */
   public static Bytes32 sha2_256(Bytes input) {
-    if (USE_SODIUM && Sodium.isAvailable()) {
+    if (isSodiumAvailable()) {
       SHA256Hash.Input shaInput = SHA256Hash.Input.fromBytes(input);
       try {
         SHA256Hash.Hash result = SHA256Hash.hash(shaInput);
@@ -128,6 +128,14 @@ public final class Hash {
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalStateException("Algorithm should be available but was not", e);
     }
+  }
+
+  private static boolean isSodiumAvailable() {
+    if (!USE_SODIUM) {
+      return false;
+    }
+    USE_SODIUM = Sodium.isAvailable();
+    return USE_SODIUM;
   }
 
   /**

--- a/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
+++ b/crypto/src/main/java/org/apache/tuweni/crypto/Hash.java
@@ -12,6 +12,8 @@
  */
 package org.apache.tuweni.crypto;
 
+import static java.util.Objects.requireNonNull;
+
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.crypto.sodium.SHA256Hash;
@@ -19,8 +21,6 @@ import org.apache.tuweni.crypto.sodium.Sodium;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Various utilities for providing hashes (digests) of arbitrary data.


### PR DESCRIPTION
## PR description
Resolves a major performance degradation in `Hash` when libsodium is not available.  Previously every hash operation would try to load sodium which involves listing multiple directories to try to find the library and creating and throwing an exception.

Now when sodium is found to be unavailable `USE_SODIUM` is set to false to avoid repeatedly trying to load it.  Additionally applications can set a system property to completely disable use of libsodium (at least for Teku using it causes immediate `OutOfMemoryError`).