### PR TITLE
Add optimised update(MessageDigest) implementation for ConcatenatedBytes

### DIFF
--- a/bytes/build.gradle
+++ b/bytes/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   testImplementation 'io.vertx:vertx-core'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'
+  testImplementation 'org.mockito:mockito-junit-jupiter'
 
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/ConcatenatedBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/ConcatenatedBytes.java
@@ -16,6 +16,8 @@ package org.apache.tuweni.bytes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkElementIndex;
 
+import java.security.MessageDigest;
+
 final class ConcatenatedBytes extends AbstractBytes {
 
   private final Bytes[] values;
@@ -181,6 +183,13 @@ final class ConcatenatedBytes extends AbstractBytes {
         destinationOffset);
 
     copyToUnchecked(destination, destinationOffset);
+  }
+
+  @Override
+  public void update(MessageDigest digest) {
+    for (Bytes value : values) {
+      value.update(digest);
+    }
   }
 
   @Override

--- a/bytes/src/test/java/org/apache/tuweni/bytes/ConcatenatedBytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/ConcatenatedBytesTest.java
@@ -17,7 +17,10 @@ import static org.apache.tuweni.bytes.Bytes.wrap;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
 
+import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
@@ -25,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InOrder;
 
 class ConcatenatedBytesTest {
 
@@ -122,5 +126,20 @@ class ConcatenatedBytesTest {
     int hashCode = bytes.hashCode();
     dest.set(1, (byte) 123);
     assertNotEquals(hashCode, bytes.hashCode());
+  }
+
+  @Test
+  void shouldUpdateMessageDigest() {
+    Bytes value1 = fromHexString("0x01234567");
+    Bytes value2 = fromHexString("0x89ABCDEF");
+    Bytes value3 = fromHexString("0x01234567");
+    Bytes bytes = wrap(value1, value2, value3);
+    MessageDigest digest = mock(MessageDigest.class);
+    bytes.update(digest);
+
+    final InOrder inOrder = inOrder(digest);
+    inOrder.verify(digest).update(value1.toArrayUnsafe(), 0, 4);
+    inOrder.verify(digest).update(value2.toArrayUnsafe(), 0, 4);
+    inOrder.verify(digest).update(value3.toArrayUnsafe(), 0, 4);
   }
 }


### PR DESCRIPTION
## PR description
Override the implementation of `update(MessageDigest)` in `ConcatenatedBytes` to avoid copying the concatenated values into a temporary array.