### PR TITLE
Do not convert identifier to lower case when parsing file in FileBackedFingerprintRepository

### DIFF
--- a/net/src/main/java/org/apache/tuweni/net/tls/FileBackedFingerprintRepository.java
+++ b/net/src/main/java/org/apache/tuweni/net/tls/FileBackedFingerprintRepository.java
@@ -158,7 +158,7 @@ final class FileBackedFingerprintRepository implements FingerprintRepository {
     if (segments.length != 2) {
       throw new IOException("Invalid line");
     }
-    String identifier = segments[0].toLowerCase();
+    String identifier = segments[0];
     String fingerprintString = segments[1].trim().replace(":", "");
     Bytes fingerprint;
     try {

--- a/net/src/test/java/org/apache/tuweni/net/tls/FileBackedFingerprintRepositoryTest.java
+++ b/net/src/test/java/org/apache/tuweni/net/tls/FileBackedFingerprintRepositoryTest.java
@@ -52,6 +52,23 @@ class FileBackedFingerprintRepositoryTest {
   }
 
   @Test
+  void testCaseSensitiveIdentifier(@TempDirectory Path tempFolder) throws IOException {
+    Path repoFile = tempFolder.resolve("repo");
+    String identifier1 = "foo";
+    String identifier2 = "Foo";
+
+    Bytes fingerprint1 = generateFingerprint();
+    Bytes fingerprint2 = generateFingerprint();
+
+    String content = String.format("%s %s%n%s %s", identifier1, fingerprint1, identifier2, fingerprint2);
+    Files.writeString(repoFile, content);
+
+    FileBackedFingerprintRepository repo = new FileBackedFingerprintRepository(repoFile);
+    assertTrue(repo.contains(identifier1, fingerprint1));
+    assertTrue(repo.contains(identifier2, fingerprint2));
+  }
+
+  @Test
   FileBackedFingerprintRepository testAddingNewFingerprint(@TempDirectory Path tempFolder) throws IOException {
     FileBackedFingerprintRepository repo = new FileBackedFingerprintRepository(tempFolder.resolve("repo"));
     Bytes fingerprint = generateFingerprint();


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->
## PR description
Do not convert identifier to lower case when parsing file in FileBackedFingerprintRepository. Converting to lowercase results in identifier not found when mixed case common name is presented. 

