### PR TITLE
move PersistenceMarshaller to kv

### DIFF
--- a/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
+++ b/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
@@ -43,6 +43,7 @@ import org.apache.tuweni.metrics.MetricsService
 import org.apache.tuweni.kv.InfinispanKeyValueStore
 import org.apache.tuweni.kv.LevelDBKeyValueStore
 import org.apache.tuweni.kv.MapKeyValueStore
+import org.apache.tuweni.kv.PersistenceMarshaller
 import org.apache.tuweni.rlpx.RLPxService
 import org.apache.tuweni.rlpx.vertx.VertxRLPxService
 import org.apache.tuweni.units.bigints.UInt256

--- a/kv/src/main/kotlin/org/apache/tuweni/kv/PersistenceMarshaller.kt
+++ b/kv/src/main/kotlin/org/apache/tuweni/kv/PersistenceMarshaller.kt
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.tuweni.ethclient
+package org.apache.tuweni.kv
 
 import org.apache.tuweni.bytes.Bytes
 import org.infinispan.commons.dataconversion.MediaType
@@ -22,6 +22,9 @@ import org.infinispan.commons.io.ByteBuffer
 import org.infinispan.commons.io.ByteBufferImpl
 import org.infinispan.commons.marshall.AbstractMarshaller
 
+/**
+ * Utility class to store Bytes objects in Infinispan key-value stores.
+ */
 class PersistenceMarshaller : AbstractMarshaller() {
 
   override fun objectFromByteBuffer(buf: ByteArray?, offset: Int, length: Int) = Bytes.wrap(buf!!, offset, length)


### PR DESCRIPTION
## PR description
Move `PersistenceMarshaller` to the kv library, so it can be reused by implementors using `kv`.

## Fixed Issue(s)
Fixes #264 
