### PR TITLE
Add bootnode script

### DIFF
--- a/eth-client-app/build.gradle
+++ b/eth-client-app/build.gradle
@@ -39,3 +39,12 @@ application {
   mainClassName = 'org.apache.tuweni.ethclient.EthereumClientAppKt'
   applicationName = 'tuweni'
 }
+
+tasks.register("bootnode", CreateStartScripts) {
+  applicationName = "bootnode"
+  outputDir = file("build/scripts")
+  mainClassName = 'org.apache.tuweni.ethclient.BootnodeAppKt'
+  classpath = project.tasks.getAt(JavaPlugin.JAR_TASK_NAME).outputs.files.plus(project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME))
+}
+
+assemble.dependsOn "bootnode"

--- a/eth-client-app/src/main/kotlin/org/apache/tuweni/ethclient/BootnodeApp.kt
+++ b/eth-client-app/src/main/kotlin/org/apache/tuweni/ethclient/BootnodeApp.kt
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.tuweni.ethclient
+
+import io.vertx.core.Vertx
+import kotlinx.coroutines.runBlocking
+import org.apache.tuweni.app.commons.ApplicationUtils
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import picocli.CommandLine
+import java.security.Security
+import kotlin.system.exitProcess
+
+fun main(args: Array<String>) = runBlocking {
+  ApplicationUtils.renderBanner("Apache Tuweni bootnode loading")
+  Security.addProvider(BouncyCastleProvider())
+  val opts = CommandLine.populateCommand(BootnodeAppOptions(), *args)
+
+  if (opts.help) {
+    CommandLine(opts).usage(System.out)
+    exitProcess(0)
+  }
+  if (opts.version) {
+    println("Apache Tuweni Bootnode #{ApplicationUtils.version}")
+    exitProcess(0)
+  }
+
+  val config = EthereumClientConfig.fromString(this.javaClass.getResource("/bootnode.toml")!!.readText())
+  val ethClient = EthereumClient(Vertx.vertx(), config)
+  Runtime.getRuntime().addShutdownHook(Thread { ethClient.stop() })
+  ethClient.start()
+}
+
+class BootnodeAppOptions {
+  @CommandLine.Option(names = ["-h", "--help"], description = ["Prints usage prompt"])
+  var help: Boolean = false
+
+  @CommandLine.Option(names = ["-v", "--version"], description = ["Prints version"])
+  var version: Boolean = false
+}

--- a/eth-client-app/src/main/resources/bootnode.toml
+++ b/eth-client-app/src/main/resources/bootnode.toml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[metrics]
+networkInterface="127.0.0.1"
+port=9092
+[discovery.default]
+networkInterface="0.0.0.0"
+port=30303
+peerRepository="default"


### PR DESCRIPTION
## PR description
Adds a separate start script, and the necessary configuration and bindings, to have the ethereum client run as a bootnode.

## Fixed Issue(s)
Fixes #174
