### PR TITLE
use ExpiringMaps instead of HashMaps for EthClient and EthClient66

### DIFF
--- a/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringMapTest.java
+++ b/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringMapTest.java
@@ -32,7 +32,7 @@ class ExpiringMapTest {
   @BeforeEach
   void setup() {
     currentTime = Instant.now();
-    map = new ExpiringMap<>(() -> currentTime.toEpochMilli());
+    map = new ExpiringMap<>(() -> currentTime.toEpochMilli(), Long.MAX_VALUE);
   }
 
   @Test
@@ -167,5 +167,13 @@ class ExpiringMapTest {
     map.forEach((k, v) -> called.set(true));
     assertTrue(called.get());
     assertEquals(new ExpiringMap<Integer, String>(), new ExpiringMap<Integer, String>());
+  }
+
+  @Test
+  void testUsesDefaultTimeout() throws InterruptedException {
+    ExpiringMap<String, String> map = new ExpiringMap<>(10L);
+    map.put("foo", "bar");
+    Thread.sleep(11);
+    assertEquals("bar", map.get("foo"));
   }
 }

--- a/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthClient.kt
+++ b/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthClient.kt
@@ -18,6 +18,7 @@ package org.apache.tuweni.devp2p.eth
 
 import org.apache.tuweni.bytes.Bytes
 import org.apache.tuweni.concurrent.AsyncResult
+import org.apache.tuweni.concurrent.ExpiringMap
 import org.apache.tuweni.eth.Block
 import org.apache.tuweni.eth.BlockBody
 import org.apache.tuweni.eth.BlockHeader
@@ -42,10 +43,10 @@ open class EthClient(
 ) :
   EthRequestsManager, SubProtocolClient {
 
-  private val headerRequests = HashMap<String, Request<List<BlockHeader>>>()
-  private val bodiesRequests = HashMap<String, Request<List<BlockBody>>>()
-  private val nodeDataRequests = HashMap<String, Request<List<Bytes?>>>()
-  private val transactionReceiptRequests = HashMap<String, Request<List<List<TransactionReceipt>>>>()
+  private val headerRequests = ExpiringMap<String, Request<List<BlockHeader>>>(600000)
+  private val bodiesRequests = ExpiringMap<String, Request<List<BlockBody>>>(600000)
+  private val nodeDataRequests = ExpiringMap<String, Request<List<Bytes?>>>(600000)
+  private val transactionReceiptRequests = ExpiringMap<String, Request<List<List<TransactionReceipt>>>>(600000)
 
   override fun connectionSelectionStrategy() = connectionSelectionStrategy
 

--- a/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthClient66.kt
+++ b/devp2p-eth/src/main/kotlin/org/apache/tuweni/devp2p/eth/EthClient66.kt
@@ -18,6 +18,7 @@ package org.apache.tuweni.devp2p.eth
 
 import org.apache.tuweni.bytes.Bytes
 import org.apache.tuweni.concurrent.AsyncResult
+import org.apache.tuweni.concurrent.ExpiringMap
 import org.apache.tuweni.eth.Block
 import org.apache.tuweni.eth.BlockBody
 import org.apache.tuweni.eth.BlockHeader
@@ -45,10 +46,10 @@ class EthClient66(
     val logger = LoggerFactory.getLogger(EthClient66::class.java)
   }
 
-  private val headerRequests = mutableMapOf<Bytes, Request<List<BlockHeader>>>()
-  private val bodiesRequests = HashMap<Bytes, Request<List<BlockBody>>>()
-  private val nodeDataRequests = HashMap<Bytes, Request<List<Bytes?>>>()
-  private val transactionReceiptRequests = HashMap<Bytes, Request<List<List<TransactionReceipt>>>>()
+  private val headerRequests = ExpiringMap<Bytes, Request<List<BlockHeader>>>(600000)
+  private val bodiesRequests = ExpiringMap<Bytes, Request<List<BlockBody>>>(600000)
+  private val nodeDataRequests = ExpiringMap<Bytes, Request<List<Bytes?>>>(600000)
+  private val transactionReceiptRequests = ExpiringMap<Bytes, Request<List<List<TransactionReceipt>>>>(600000)
 
   override fun connectionSelectionStrategy() = connectionSelectionStrategy
 


### PR DESCRIPTION
## PR description
use ExpiringMaps instead of HashMaps for EthClient and EthClient66

This way, we will see requests expire after a bit. By default, the timeout is set to 10 minutes.

## Fixed Issue(s)
fixes #255