### PR TITLE
Log at DEBUG level when no nodes are resolved

### DIFF
--- a/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
+++ b/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSResolver.kt
@@ -93,7 +93,11 @@ class DNSResolver @JvmOverloads constructor(
       }
     }
     visitTree(enrLink, visitor)
-    logger.info("Resolved ${nodes.size} nodes")
+    if (nodes.size > 0) {
+      logger.info("Resolved ${nodes.size} nodes")
+    } else {
+      logger.debug("No nodes resolved")
+    }
     return nodes
   }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description

Only log, the number of resolved nodes at INFO level, when the list of nodes is not empty, to avoid having a lot of log lines with "Resolved 0 nodes" that could confuse the user

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
fixes #370 
