### PR TITLE
Speed up copyTo operation 

### DIFF
--- a/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
@@ -1391,9 +1391,7 @@ public interface Bytes extends Comparable<Bytes> {
         destination.size() - destinationOffset,
         destinationOffset);
 
-    for (int i = 0; i < size; i++) {
-      destination.set(destinationOffset + i, get(i));
-    }
+    destination.set(destinationOffset, this);
   }
 
   /**

--- a/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingBytes.java
@@ -13,12 +13,12 @@
 package org.apache.tuweni.bytes;
 
 
-import io.vertx.core.buffer.Buffer;
-
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.MessageDigest;
+
+import io.vertx.core.buffer.Buffer;
 
 /**
  * A class that holds and delegates all operations to its inner bytes field.

--- a/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingBytes.java
@@ -13,6 +13,12 @@
 package org.apache.tuweni.bytes;
 
 
+import io.vertx.core.buffer.Buffer;
+
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
 
 /**
  * A class that holds and delegates all operations to its inner bytes field.
@@ -51,6 +57,256 @@ public class DelegatingBytes extends AbstractBytes implements Bytes {
   @Override
   public MutableBytes mutableCopy() {
     return MutableBytes.wrap(toArray());
+  }
+
+  @Override
+  public byte[] toArray() {
+    return delegate.toArray();
+  }
+
+  @Override
+  public byte[] toArray(ByteOrder byteOrder) {
+    return delegate.toArray(byteOrder);
+  }
+
+  @Override
+  public byte[] toArrayUnsafe() {
+    return delegate.toArrayUnsafe();
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
+  @Override
+  public int getInt(int i) {
+    return delegate.getInt(i);
+  }
+
+  @Override
+  public int getInt(int i, ByteOrder order) {
+    return delegate.getInt(i, order);
+  }
+
+  @Override
+  public int toInt() {
+    return delegate.toInt();
+  }
+
+  @Override
+  public int toInt(ByteOrder order) {
+    return delegate.toInt(order);
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
+  public long getLong(int i) {
+    return delegate.getLong(i);
+  }
+
+  @Override
+  public long getLong(int i, ByteOrder order) {
+    return delegate.getLong(i, order);
+  }
+
+  @Override
+  public long toLong() {
+    return delegate.toLong();
+  }
+
+  @Override
+  public long toLong(ByteOrder order) {
+    return delegate.toLong(order);
+  }
+
+  @Override
+  public BigInteger toBigInteger() {
+    return delegate.toBigInteger();
+  }
+
+  @Override
+  public BigInteger toBigInteger(ByteOrder order) {
+    return delegate.toBigInteger(order);
+  }
+
+  @Override
+  public BigInteger toUnsignedBigInteger() {
+    return delegate.toUnsignedBigInteger();
+  }
+
+  @Override
+  public BigInteger toUnsignedBigInteger(ByteOrder order) {
+    return delegate.toUnsignedBigInteger(order);
+  }
+
+  @Override
+  public boolean isZero() {
+    return delegate.isZero();
+  }
+
+  @Override
+  public boolean hasLeadingZero() {
+    return delegate.hasLeadingZero();
+  }
+
+  @Override
+  public int numberOfLeadingZeros() {
+    return delegate.numberOfLeadingZeros();
+  }
+
+  @Override
+  public boolean hasLeadingZeroByte() {
+    return delegate.hasLeadingZeroByte();
+  }
+
+  @Override
+  public int numberOfLeadingZeroBytes() {
+    return delegate.numberOfLeadingZeroBytes();
+  }
+
+  @Override
+  public int numberOfTrailingZeroBytes() {
+    return delegate.numberOfTrailingZeroBytes();
+  }
+
+  @Override
+  public int bitLength() {
+    return delegate.bitLength();
+  }
+
+  @Override
+  public Bytes and(Bytes other) {
+    return delegate.and(other);
+  }
+
+  @Override
+  public <T extends MutableBytes> T and(Bytes other, T result) {
+    return delegate.and(other, result);
+  }
+
+  @Override
+  public Bytes or(Bytes other) {
+    return delegate.or(other);
+  }
+
+  @Override
+  public <T extends MutableBytes> T or(Bytes other, T result) {
+    return delegate.or(other, result);
+  }
+
+  @Override
+  public Bytes xor(Bytes other) {
+    return delegate.xor(other);
+  }
+
+  @Override
+  public <T extends MutableBytes> T xor(Bytes other, T result) {
+    return delegate.xor(other, result);
+  }
+
+  @Override
+  public <T extends MutableBytes> T shiftRight(int distance, T result) {
+    return delegate.shiftRight(distance, result);
+  }
+
+  @Override
+  public <T extends MutableBytes> T shiftLeft(int distance, T result) {
+    return delegate.shiftLeft(distance, result);
+  }
+
+  @Override
+  public Bytes slice(int i) {
+    return delegate.slice(i);
+  }
+
+  @Override
+  public void copyTo(MutableBytes destination) {
+    delegate.copyTo(destination);
+  }
+
+  @Override
+  public void copyTo(MutableBytes destination, int destinationOffset) {
+    delegate.copyTo(destination, destinationOffset);
+  }
+
+  @Override
+  public void appendTo(ByteBuffer byteBuffer) {
+    delegate.appendTo(byteBuffer);
+  }
+
+  @Override
+  public void appendTo(Buffer buffer) {
+    delegate.appendTo(buffer);
+  }
+
+  @Override
+  public <T extends Appendable> T appendHexTo(T appendable) {
+    return delegate.appendHexTo(appendable);
+  }
+
+  @Override
+  public int commonPrefixLength(Bytes other) {
+    return delegate.commonPrefixLength(other);
+  }
+
+  @Override
+  public Bytes commonPrefix(Bytes other) {
+    return delegate.commonPrefix(other);
+  }
+
+  @Override
+  public Bytes trimLeadingZeros() {
+    return delegate.trimLeadingZeros();
+  }
+
+  @Override
+  public void update(MessageDigest digest) {
+    delegate.update(digest);
+  }
+
+  @Override
+  public Bytes reverse() {
+    return delegate.reverse();
+  }
+
+  @Override
+  public String toHexString() {
+    return delegate.toHexString();
+  }
+
+  @Override
+  public String toUnprefixedHexString() {
+    return delegate.toUnprefixedHexString();
+  }
+
+  @Override
+  public String toEllipsisHexString() {
+    return delegate.toEllipsisHexString();
+  }
+
+  @Override
+  public String toShortHexString() {
+    return delegate.toShortHexString();
+  }
+
+  @Override
+  public String toQuantityHexString() {
+    return delegate.toQuantityHexString();
+  }
+
+  @Override
+  public String toBase64String() {
+    return delegate.toBase64String();
+  }
+
+  @Override
+  public int compareTo(Bytes b) {
+    return delegate.compareTo(b);
   }
 
   @Override

--- a/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingMutableBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/DelegatingMutableBytes.java
@@ -40,6 +40,11 @@ public class DelegatingMutableBytes implements MutableBytes {
   }
 
   @Override
+  public void set(int i, Bytes b) {
+    delegate.set(i, b);
+  }
+
+  @Override
   public void setInt(int i, int value) {
     delegate.setInt(i, value);
   }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableArrayWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableArrayWrappingBytes.java
@@ -36,6 +36,12 @@ class MutableArrayWrappingBytes extends ArrayWrappingBytes implements MutableByt
   }
 
   @Override
+  public void set(int i, Bytes b) {
+    byte[] bytesArray = b.toArrayUnsafe();
+    System.arraycopy(bytesArray, 0, bytes, offset + i, bytesArray.length);
+  }
+
+  @Override
   public MutableBytes increment() {
     for (int i = length - 1; i >= offset; --i) {
       if (bytes[i] == (byte) 0xFF) {

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableBufferWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableBufferWrappingBytes.java
@@ -33,6 +33,12 @@ final class MutableBufferWrappingBytes extends BufferWrappingBytes implements Mu
   }
 
   @Override
+  public void set(int i, Bytes b) {
+    byte[] bytes = b.toArrayUnsafe();
+    buffer.setBytes(i, bytes);
+  }
+
+  @Override
   public void setInt(int i, int value) {
     buffer.setInt(i, value);
   }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufWrappingBytes.java
@@ -38,6 +38,12 @@ final class MutableByteBufWrappingBytes extends ByteBufWrappingBytes implements 
   }
 
   @Override
+  public void set(int i, Bytes b) {
+    byte[] bytes = b.toArrayUnsafe();
+    byteBuf.setBytes(i, bytes);
+  }
+
+  @Override
   public void setInt(int i, int value) {
     byteBuf.setInt(i, value);
   }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufferWrappingBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableByteBufferWrappingBytes.java
@@ -43,6 +43,17 @@ public class MutableByteBufferWrappingBytes extends ByteBufferWrappingBytes impl
   }
 
   @Override
+  public void set(int i, Bytes b) {
+    byte[] bytes = b.toArrayUnsafe();
+    int byteIndex = 0;
+    int thisIndex = offset + i;
+    int end = bytes.length;
+    while (byteIndex < end) {
+      byteBuffer.put(thisIndex++, bytes[byteIndex++]);
+    }
+  }
+
+  @Override
   public MutableBytes mutableSlice(int i, int length) {
     if (i == 0 && length == this.length) {
       return this;

--- a/bytes/src/main/java/org/apache/tuweni/bytes/MutableBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/MutableBytes.java
@@ -42,7 +42,7 @@ public interface MutableBytes extends Bytes {
     if (size == 32) {
       return MutableBytes32.create();
     }
-    return new MutableByteBufferWrappingBytes(ByteBuffer.allocate(size));
+    return new MutableArrayWrappingBytes(new byte[size]);
   }
 
   /**


### PR DESCRIPTION
## PR description

Several changes aimed at speeding up copyTo:

* DelgateingBytes delegates more calls to its delegate
* Bulk `set` method for setting more than one byte
* Defaulting Mutable Bytes to ByteArrays

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
