### PR TITLE
turns down logging output to debug on DNS refresh

### DIFF
--- a/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSDaemon.kt
+++ b/dns-discovery/src/main/kotlin/org/apache/tuweni/discovery/DNSDaemon.kt
@@ -85,7 +85,7 @@ internal class DNSTimerTask(
   }
 
   override fun run() {
-    logger.info("Refreshing DNS records with $enrLink")
+    logger.debug("Refreshing DNS records with $enrLink")
     records(dnsResolver.collectAll(enrLink))
   }
 }


### PR DESCRIPTION
Refreshing DNS happens regularly enough and is reliable enough that changing this to DEBUG from INFO will eliminate log noise.

Signed-off-by: Justin Florentine <justin+github@florentine.us>