### PR TITLE
ssz: Fix reader.readFixedBytesList

### DIFF
--- a/ssz/src/main/java/org/apache/tuweni/ssz/BytesSSZReader.java
+++ b/ssz/src/main/java/org/apache/tuweni/ssz/BytesSSZReader.java
@@ -147,7 +147,7 @@ final class BytesSSZReader implements SSZReader {
 
   @Override
   public List<Bytes> readFixedBytesList(int byteLength, int limit) {
-    return readList(remaining -> readFixedBytes(byteLength, limit));
+    return readList(byteLength, () -> readFixedBytes(byteLength, limit));
   }
 
   @Override

--- a/ssz/src/test/java/org/apache/tuweni/ssz/BytesSSZReaderTest.java
+++ b/ssz/src/test/java/org/apache/tuweni/ssz/BytesSSZReaderTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.apache.tuweni.bytes.Bytes48;
 
 import java.math.BigInteger;
@@ -224,5 +225,12 @@ class BytesSSZReaderTest {
     List<Bytes> toWrite = Arrays.asList(Bytes48.random(), Bytes48.random(), Bytes48.random());
     Bytes encoded = SSZ.encode(writer -> writer.writeFixedBytesVector(toWrite));
     assertEquals(toWrite, SSZ.decode(encoded, reader -> reader.readFixedBytesVector(3, 48)));
+  }
+
+  @Test
+  void shouldRoundtripHomogenousBytesList() {
+    List<Bytes32> toWrite = Arrays.asList(Bytes32.random(), Bytes32.random(), Bytes32.random());
+    Bytes encoded = SSZ.encode(writer -> writer.writeFixedBytesList(toWrite));
+    assertEquals(toWrite, SSZ.decode(encoded, reader -> reader.readFixedBytesList(Bytes32.SIZE)));
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description
Current implementation when using `reader.readFixedBytesList` handles elements as variable size. Added a test to clarify this and fixed

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->
