### PR TITLE
fix docs build, disable for now

### DIFF
--- a/.github/workflows/docs.yml.disable
+++ b/.github/workflows/docs.yml.disable
@@ -1,5 +1,3 @@
-# FIXME docs build runs into OOMs. It will be fixed with the move to Java 17.
-
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# FIXME: breaks with https://github.com/Kotlin/dokka/issues/2572
 
 name: docs
 


### PR DESCRIPTION
## PR description
Fixes the doc build by disabling it while https://github.com/Kotlin/dokka/issues/2572 is occurring.
