### PR TITLE
speed up hex string to bytes and back

### DIFF
--- a/bytes/src/main/java/org/apache/tuweni/bytes/AbstractBytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/AbstractBytes.java
@@ -18,7 +18,8 @@ package org.apache.tuweni.bytes;
  */
 public abstract class AbstractBytes implements Bytes {
 
-  static final char[] HEX_CODE = "0123456789abcdef".toCharArray();
+  static final String HEX_CODE_AS_STRING = "0123456789abcdef";
+  static final char[] HEX_CODE = HEX_CODE_AS_STRING.toCharArray();
 
   private Integer hashCode;
 

--- a/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
@@ -25,6 +25,7 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -1434,16 +1435,35 @@ public interface Bytes extends Comparable<Bytes> {
    */
   default <T extends Appendable> T appendHexTo(T appendable) {
     try {
-      int size = size();
-      for (int i = 0; i < size; i++) {
-        byte b = get(i);
-        appendable.append(AbstractBytes.HEX_CODE[b >> 4 & 15]);
-        appendable.append(AbstractBytes.HEX_CODE[b & 15]);
-      }
+      appendable.append(toFastHex(false));
       return appendable;
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  default String toFastHex(boolean prefix){
+
+    int offset = prefix ? 2 : 0;
+
+    int resultSize = (size() * 2) + offset;
+
+    char[] result = new char[resultSize];
+
+    if (prefix) {
+      result[0] = '0';
+      result[1] = 'x';
+    }
+
+    for (int i = 0; i < size(); i++) {
+      byte b = get(i);
+      int pos = i * 2;
+      result[pos + offset] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b >> 4 & 15);
+      result[pos + offset + 1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
+    }
+
+    return new String(result);
+
   }
 
   /**
@@ -1585,7 +1605,7 @@ public interface Bytes extends Comparable<Bytes> {
    * @return This value represented as hexadecimal, starting with "0x".
    */
   default String toHexString() {
-    return appendHexTo(new StringBuilder("0x")).toString();
+    return toFastHex(true);
   }
 
   /**
@@ -1594,7 +1614,7 @@ public interface Bytes extends Comparable<Bytes> {
    * @return This value represented as hexadecimal, with no prefix.
    */
   default String toUnprefixedHexString() {
-    return appendHexTo(new StringBuilder()).toString();
+    return toFastHex(false);
   }
 
   default String toEllipsisHexString() {
@@ -1602,19 +1622,24 @@ public interface Bytes extends Comparable<Bytes> {
     if (size < 6) {
       return toHexString();
     }
-    StringBuilder appendable = new StringBuilder("0x");
+    char[] result = new char[12];
+    result[0] = '0';
+    result[1] = 'x';
     for (int i = 0; i < 2; i++) {
       byte b = get(i);
-      appendable.append(AbstractBytes.HEX_CODE[b >> 4 & 15]);
-      appendable.append(AbstractBytes.HEX_CODE[b & 15]);
+      int pos = (i * 2) + 2;
+      result[pos] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b >> 4 & 15);
+      result[pos+1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
     }
-    appendable.append("..");
+    result[6] = '.';
+    result[7] = '.';
     for (int i = 0; i < 2; i++) {
       byte b = get(i + size - 2);
-      appendable.append(AbstractBytes.HEX_CODE[b >> 4 & 15]);
-      appendable.append(AbstractBytes.HEX_CODE[b & 15]);
+      int pos = (i * 2) + 8;
+      result[pos] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b >> 4 & 15);
+      result[pos+1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
     }
-    return appendable.toString();
+    return new String(result);
   }
 
   /**
@@ -1623,7 +1648,7 @@ public interface Bytes extends Comparable<Bytes> {
    * @return This value represented as a minimal hexadecimal string (without any leading zero).
    */
   default String toShortHexString() {
-    StringBuilder hex = appendHexTo(new StringBuilder());
+    String hex = toFastHex(false);
 
     int i = 0;
     while (i < hex.length() && hex.charAt(i) == '0') {
@@ -1643,13 +1668,13 @@ public interface Bytes extends Comparable<Bytes> {
     if (Bytes.EMPTY.equals(this)) {
       return "0x0";
     }
-    StringBuilder hex = appendHexTo(new StringBuilder());
+    String hex = toFastHex(false);
 
     int i = 0;
     while (i < hex.length() - 1 && hex.charAt(i) == '0') {
       i++;
     }
-    return "0x" + hex.substring(hex.charAt(hex.length() - 1) == '0' ? i : i++);
+    return "0x" + hex.substring(i);
   }
 
   /**

--- a/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
@@ -25,7 +25,6 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ReadOnlyBufferException;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
@@ -1442,7 +1441,7 @@ public interface Bytes extends Comparable<Bytes> {
     }
   }
 
-  default String toFastHex(boolean prefix){
+  default String toFastHex(boolean prefix) {
 
     int offset = prefix ? 2 : 0;
 
@@ -1629,7 +1628,7 @@ public interface Bytes extends Comparable<Bytes> {
       byte b = get(i);
       int pos = (i * 2) + 2;
       result[pos] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b >> 4 & 15);
-      result[pos+1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
+      result[pos + 1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
     }
     result[6] = '.';
     result[7] = '.';
@@ -1637,7 +1636,7 @@ public interface Bytes extends Comparable<Bytes> {
       byte b = get(i + size - 2);
       int pos = (i * 2) + 8;
       result[pos] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b >> 4 & 15);
-      result[pos+1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
+      result[pos + 1] = AbstractBytes.HEX_CODE_AS_STRING.charAt(b & 15);
     }
     return new String(result);
   }

--- a/bytes/src/main/java/org/apache/tuweni/bytes/BytesValues.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/BytesValues.java
@@ -58,19 +58,21 @@ final class BytesValues {
       int h = Character.digit(hex.charAt(j), 16);
       if (h == -1) {
         throw new IllegalArgumentException(
-                String
-                        .format("Illegal character '%c' found at index %d in hex binary representation",
-                                hex.charAt(j),
-                                j - idxShift));
+            String
+                .format(
+                    "Illegal character '%c' found at index %d in hex binary representation",
+                    hex.charAt(j),
+                    j - idxShift));
       }
       j++;
       int l = Character.digit(hex.charAt(j), 16);
       if (l == -1) {
         throw new IllegalArgumentException(
-                String
-                        .format("Illegal character '%c' found at index %d in hex binary representation",
-                                hex.charAt(j),
-                                j - idxShift));
+            String
+                .format(
+                    "Illegal character '%c' found at index %d in hex binary representation",
+                    hex.charAt(j),
+                    j - idxShift));
       }
       j++;
       out[i] = (byte) ((h << 4) + l);

--- a/bytes/src/main/java/org/apache/tuweni/bytes/BytesValues.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/BytesValues.java
@@ -34,7 +34,7 @@ final class BytesValues {
     }
 
     int idxShift = 0;
-    if (len % 2 != 0) {
+    if ((len & 0x01) != 0) {
       if (!lenient) {
         throw new IllegalArgumentException("Invalid odd-length hex binary representation");
       }
@@ -44,7 +44,7 @@ final class BytesValues {
       idxShift = 1;
     }
 
-    int size = len / 2;
+    int size = len >> 1;
     if (destSize < 0) {
       destSize = size;
     } else {
@@ -54,38 +54,28 @@ final class BytesValues {
     byte[] out = new byte[destSize];
 
     int destOffset = (destSize - size);
-    for (int i = 0; i < len; i += 2) {
-      int h = hexToBin(hex.charAt(i));
-      int l = hexToBin(hex.charAt(i + 1));
+    for (int i = destOffset, j = 0; j < len; i++) {
+      int h = Character.digit(hex.charAt(j), 16);
       if (h == -1) {
         throw new IllegalArgumentException(
-            String
-                .format(
-                    "Illegal character '%c' found at index %d in hex binary representation",
-                    hex.charAt(i),
-                    i - idxShift));
+                String
+                        .format("Illegal character '%c' found at index %d in hex binary representation",
+                                hex.charAt(j),
+                                j - idxShift));
       }
+      j++;
+      int l = Character.digit(hex.charAt(j), 16);
       if (l == -1) {
         throw new IllegalArgumentException(
-            String
-                .format(
-                    "Illegal character '%c' found at index %d in hex binary representation",
-                    hex.charAt(i + 1),
-                    i + 1 - idxShift));
+                String
+                        .format("Illegal character '%c' found at index %d in hex binary representation",
+                                hex.charAt(j),
+                                j - idxShift));
       }
-
-      out[destOffset + (i / 2)] = (byte) (h * 16 + l);
+      j++;
+      out[i] = (byte) ((h << 4) + l);
     }
     return out;
   }
 
-  private static int hexToBin(char ch) {
-    if ('0' <= ch && ch <= '9') {
-      return ch - 48;
-    } else if ('A' <= ch && ch <= 'F') {
-      return ch - 65 + 10;
-    } else {
-      return 'a' <= ch && ch <= 'f' ? ch - 97 + 10 : -1;
-    }
-  }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## faster hex string to bytes conversions

Hello, I found a couple of tweaks for the conversions from bytes to hexadecimal strings and vice versa. 

from the numbers I get on my machine (ryzen 5900x)
* from bytes to hex string at least 2x better
* from hex string to bytes at least 2x better

I have a branch in my fork with the benchmarks if anyone wants to compare the numbers on different cpus, they can be run with './gradlew jmh'

[https://github.com/rudygt/incubator-tuweni/tree/benchmarks](url)

pd: do we have any project/benchmark already in the repo where the improvements in the bytes package could be seen? (tying to find out how these changes help/hurt real use cases)

Thanks!

## micro benchmark results (the changes in this pull request come from the candidate methods)
```
Benchmark                                        Mode  Cnt      Score   Error  Units
BasicBenchmark.toHexByteBufferCandidate         thrpt    2   7409.498          ops/s
BasicBenchmark.toHexCandidate                   thrpt    2  11958.619          ops/s
BasicBenchmark.toHexOriginal                    thrpt    2   4334.624          ops/s
FromHexBenchmark.fromHexCandidate               thrpt    2  14410.351          ops/s
FromHexBenchmark.fromHexOriginal                thrpt    2   6172.697          ops/s
ShortHexBenchmark.toEllipsisHexStringCandidate  thrpt    2  59985.673          ops/s
ShortHexBenchmark.toEllipsisHexStringOriginal   thrpt    2  40314.218          ops/s
```