### PR TITLE
fix zero compares of different lengths

### DIFF
--- a/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
+++ b/bytes/src/main/java/org/apache/tuweni/bytes/Bytes.java
@@ -1687,9 +1687,14 @@ public interface Bytes extends Comparable<Bytes> {
   default int compareTo(Bytes b) {
     checkNotNull(b);
 
-    int sizeCmp = Integer.compare(bitLength(), b.bitLength());
+    int bitLength = bitLength();
+    int sizeCmp = Integer.compare(bitLength, b.bitLength());
     if (sizeCmp != 0) {
       return sizeCmp;
+    }
+    // same bitlength and is zeroes only, return 0.
+    if (bitLength == 0) {
+      return 0;
     }
 
     for (int i = 0; i < size(); i++) {

--- a/bytes/src/test/java/org/apache/tuweni/bytes/BytesTest.java
+++ b/bytes/src/test/java/org/apache/tuweni/bytes/BytesTest.java
@@ -309,6 +309,10 @@ class BytesTest extends CommonBytesTests {
     assertEquals(-1, Bytes.of(0x01).compareTo(Bytes.of(0x01, 0xff)));
     assertEquals(-1, Bytes.of(0x00, 0x00, 0x01).compareTo(Bytes.of(0x00, 0x02)));
     assertEquals(-1, Bytes.of(0x00, 0x01).compareTo(Bytes.of(0x00, 0x00, 0x05)));
+    assertEquals(0, Bytes.fromHexString("0x0000").compareTo(Bytes.fromHexString("0x00")));
+    assertEquals(0, Bytes.fromHexString("0x00").compareTo(Bytes.fromHexString("0x0000")));
+    assertEquals(0, Bytes.fromHexString("0x000000").compareTo(Bytes.fromHexString("0x000000")));
+    assertEquals(-1, Bytes.fromHexString("0x000001").compareTo(Bytes.fromHexString("0x0001")));
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description
Fixes a corner case of bytes comparisons if both objects are only representing zero bytes, but they have different sizes.
