### PR TITLE
jsonrpc: fix content-type header and response logging

### DIFF
--- a/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/JSONRPCClient.kt
+++ b/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/JSONRPCClient.kt
@@ -81,7 +81,6 @@ class JSONRPCClient(
       if (response.failed()) {
         deferred.completeExceptionally(response.cause())
       } else {
-        println(response.result().bodyAsString())
         val jsonResponse = mapper.readValue(response.result().bodyAsString(), JSONRPCResponse::class.java)
         deferred.complete(jsonResponse)
       }

--- a/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/JSONRPCServer.kt
+++ b/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/JSONRPCServer.kt
@@ -165,11 +165,15 @@ class JSONRPCServer(
             responses.add(handleRequest(request))
           }
           val readyResponses = responses.awaitAll()
+
+          val httpResponse = httpRequest.response().putHeader("content-type", "application/json")
+
           if (readyResponses.size == 1) {
-            httpRequest.response().end(mapper.writeValueAsString(readyResponses.get(0)))
+            httpResponse.end(mapper.writeValueAsString(readyResponses.get(0)))
           } else {
-            httpRequest.response().end(mapper.writeValueAsString(readyResponses))
+            httpResponse.end(mapper.writeValueAsString(readyResponses))
           }
+
           span.end()
         }
       }

--- a/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/methods/MethodsHandler.kt
+++ b/jsonrpc/src/main/kotlin/org/apache/tuweni/jsonrpc/methods/MethodsHandler.kt
@@ -220,7 +220,7 @@ class LoggingHandler(
   suspend fun handleRequest(request: JSONRPCRequest): JSONRPCResponse {
     logger.info(request.toString())
     val response = delegateHandler.invoke(request)
-    logger.info(response.toString())
+    logger.debug(response.toString())
     return response
   }
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description
While the jsonrpc proxy sends the correct headers on the client side (to the node) the server is missing the content-type completely. Most frameworks assume `application/octet-stream` then and this introduces issues with downstream apps. This PR adds the specification `application/json` .

At INFO level it logged the whole response data 2 times, one via `println` which is impossible to disable by config.  Depending on the calls used this can cause tens of MBs per minute of logs. Removes the println and reduces the very verbose logging to debug level.
