### PR TITLE
using compile only for annotation dependencies that are used for static code analysis

### DIFF
--- a/bytes/build.gradle
+++ b/bytes/build.gradle
@@ -15,8 +15,8 @@ description = 'Classes and utilities for working with byte arrays.'
 dependencies {
   implementation 'org.connid:framework'
   implementation 'org.connid:framework-internal'
-  implementation 'com.google.code.findbugs:jsr305'
-  implementation 'com.google.errorprone:error_prone_annotations'
+  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.errorprone:error_prone_annotations'
   compileOnly 'io.vertx:vertx-core'
 
   testImplementation 'io.vertx:vertx-core'

--- a/concurrent/build.gradle
+++ b/concurrent/build.gradle
@@ -14,8 +14,8 @@ description = 'Classes and utilities for working with concurrency.'
 
 dependencies {
   compileOnly 'io.vertx:vertx-core'
-  implementation 'com.google.code.findbugs:jsr305'
-  implementation 'com.google.errorprone:error_prone_annotations'
+  compileOnly 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.errorprone:error_prone_annotations'
 
   testImplementation project(':junit')
   testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/config/build.gradle
+++ b/config/build.gradle
@@ -14,7 +14,7 @@ description = 'Classes and utilities for working with configuration.'
 
 dependencies {
   implementation project(':toml')
-  implementation 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.code.findbugs:jsr305'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -19,8 +19,8 @@ dependencies {
   implementation project(':io')
   implementation project(':units')
   implementation 'com.github.jnr:jnr-ffi'
-  implementation 'com.google.code.findbugs:jsr305'
 
+  compileOnly 'com.google.code.findbugs:jsr305'
   compileOnly 'org.bouncycastle:bcprov-jdk15on'
   compileOnly 'org.miracl.milagro.amcl:milagro-crypto-java'
 

--- a/plumtree/build.gradle
+++ b/plumtree/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation project(':concurrent')
   implementation project(':crypto')
 
-  implementation 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.code.findbugs:jsr305'
   implementation 'com.fasterxml.jackson.core:jackson-databind'
 
   compileOnly 'io.vertx:vertx-core'

--- a/pow/build.gradle
+++ b/pow/build.gradle
@@ -17,8 +17,9 @@ dependencies {
   implementation project(':concurrent')
   implementation project(':crypto')
   implementation project(':units')
-  implementation 'com.google.code.findbugs:jsr305'
   implementation 'org.bouncycastle:bcprov-jdk15on'
+
+  compileOnly 'com.google.code.findbugs:jsr305'
 
   testImplementation project(':junit')
   testImplementation 'org.bouncycastle:bcprov-jdk15on'

--- a/scuttlebutt-handshake/build.gradle
+++ b/scuttlebutt-handshake/build.gradle
@@ -19,10 +19,12 @@ dependencies {
   implementation project(':crypto')
   implementation project(':scuttlebutt')
   implementation 'org.slf4j:slf4j-api'
-  implementation 'com.google.code.findbugs:jsr305'
   implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core'
   implementation 'io.vertx:vertx-lang-kotlin-coroutines'
   implementation 'io.vertx:vertx-core'
+
+  compileOnly 'com.google.code.findbugs:jsr305'
+
 
   testImplementation project(':junit')
 

--- a/toml/build.gradle
+++ b/toml/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   antlr 'org.antlr:antlr4'
 
   implementation 'org.antlr:antlr4-runtime'
-  implementation 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.code.findbugs:jsr305'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'

--- a/units/build.gradle
+++ b/units/build.gradle
@@ -14,7 +14,7 @@ description = 'Classes and utilities for working with 256 bit integers.'
 
 dependencies {
   implementation project(':bytes')
-  implementation 'com.google.code.findbugs:jsr305'
+  compileOnly 'com.google.code.findbugs:jsr305'
 
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'


### PR DESCRIPTION
Annotations of JSR305 only need to be at compile time on the classpath. In the current version it will be added as a transitive dependency to other projects that depend on tuweni. By defining the dependencies as compile only they won't be passt as a transitive dependency to other projects.