### PR TITLE
Add a global expiration listener

### DIFF
--- a/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringMapTest.java
+++ b/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringMapTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ class ExpiringMapTest {
   @BeforeEach
   void setup() {
     currentTime = Instant.now();
-    map = new ExpiringMap<>(() -> currentTime.toEpochMilli(), Long.MAX_VALUE);
+    map = new ExpiringMap<>(() -> currentTime.toEpochMilli(), Long.MAX_VALUE, null);
   }
 
   @Test
@@ -73,6 +74,21 @@ class ExpiringMapTest {
     assertTrue(map.isEmpty());
 
     assertNull(map.remove(1));
+  }
+
+  @Test
+  void addGlobalExpiryListener() {
+    AtomicReference<String> key = new AtomicReference<>();
+    AtomicReference<String> value = new AtomicReference<>();
+    ExpiringMap<String, String> listeningMap =
+        new ExpiringMap<>(() -> currentTime.toEpochMilli(), 1L, (String k, String v) -> {
+          key.set(k);
+          value.set(v);
+        });
+    listeningMap.put("foo", "bar", -1);
+    assertEquals("foo", key.get());
+    assertEquals("bar", value.get());
+    assertEquals(0, listeningMap.size());
   }
 
   @Test

--- a/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringSetTest.java
+++ b/concurrent/src/test/java/org/apache/tuweni/concurrent/ExpiringSetTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,7 +30,7 @@ class ExpiringSetTest {
   @BeforeEach
   void setup() {
     currentTime = Instant.now();
-    set = new ExpiringSet<>(Long.MAX_VALUE, () -> currentTime.toEpochMilli());
+    set = new ExpiringSet<>(Long.MAX_VALUE, () -> currentTime.toEpochMilli(), null);
   }
 
   @Test
@@ -60,6 +61,15 @@ class ExpiringSetTest {
     assertTrue(set.isEmpty());
 
     assertFalse(set.remove("foo"));
+  }
+
+  @Test
+  void addGlobalExpiryListener() {
+    AtomicReference<String> key = new AtomicReference<>();
+    ExpiringSet<String> listeningSet = new ExpiringSet<>(1L, () -> currentTime.toEpochMilli(), key::set);
+    listeningSet.add("foo", -1);
+    assertEquals("foo", key.get());
+    assertEquals(0, listeningSet.size());
   }
 
   @Test


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Please check out our contribution guidelines: -->
<!-- https://github.com/apache/incubator-tuweni/blob/main/CONTRIBUTING.md -->

## PR description
Allow to set a global expiry listener for ExpiringMap and ExpiringSet that gets called unless a specific expiry listener is set on the entry.

## Fixed Issue(s)
Fixes #122 