### PR TITLE
Upgrade gradle to 7.6 in the docker image and in the build.

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -54,7 +54,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/dependency-versions.gradle') }}
           restore-keys: ${{ runner.os }}-m2
       - name: gradle assemble
-        run: ./gradlew assemble -x test -Psignatory.keyId=38F6C7215DD49C32 -Psigning.gnupg.keyName=38F6C7215DD49C32 -Psigning.gnupg.executable=gpg
+        run: gradle assemble -x test -Psignatory.keyId=38F6C7215DD49C32 -Psigning.gnupg.keyName=38F6C7215DD49C32 -Psigning.gnupg.executable=gpg
         env:
           ENABLE_SIGNING: true
       - name: Upload source distrib

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,4 +34,4 @@ jobs:
         with:
           submodules: true
       - name: gradle rat spotlessCheck checkNotice
-        run: ./gradlew rat spotlessCheck checkNotice
+        run: gradle rat spotlessCheck checkNotice

--- a/.github/workflows/docs.yml.disable
+++ b/.github/workflows/docs.yml.disable
@@ -48,7 +48,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/dependency-versions.gradle') }}
           restore-keys: ${{ runner.os }}-m2
       - name: gradle docs
-        run: ./gradlew docs
+        run: gradle docs
       - name: Upload docs
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/dependency-versions.gradle') }}
           restore-keys: ${{ runner.os }}-m2
       - name: gradle integrationTest
-        run: ./gradlew integrationTest
+        run: gradle integrationTest
       - name: Archive Junit Report
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/license-checks.yml
+++ b/.github/workflows/license-checks.yml
@@ -32,4 +32,4 @@ jobs:
         with:
           submodules: true
       - name: gradle checkLicense
-        run: ./gradlew checkLicense
+        run: gradle checkLicense

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/dependency-versions.gradle') }}
           restore-keys: ${{ runner.os }}-m2
       - name: gradle test
-        run: ./gradlew test
+        run: gradle test
       - name: Archive Junit Report
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test_referencetests.yml
+++ b/.github/workflows/test_referencetests.yml
@@ -47,7 +47,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/dependency-versions.gradle') }}
           restore-keys: ${{ runner.os }}-m2
       - name: gradle evm:referenceTest
-        run: ./gradlew evm:referenceTest
+        run: gradle evm:referenceTest
       - name: Archive Junit Report
         if: always()
         uses: actions/upload-artifact@v3

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ gradle.startParameter.taskNames.each {
 gradle.startParameter.taskNames = expandedTaskList.flatten()
 
 ext {
-  gradleVersion = '7.5'
+  gradleVersion = '7.6'
 }
 
 apply from: "${rootDir}/gradle/wrapper.gradle"

--- a/gradle/build.Dockerfile
+++ b/gradle/build.Dockerfile
@@ -51,8 +51,8 @@ RUN apt-get update \
     && which hg \
     && which svn
 
-ENV GRADLE_VERSION 7.3
-ARG GRADLE_DOWNLOAD_SHA256=de8f52ad49bdc759164f72439a3bf56ddb1589c4cde802d3cec7d6ad0e0ee410
+ENV GRADLE_VERSION 7.6
+ARG GRADLE_DOWNLOAD_SHA256=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
 RUN set -o errexit -o nounset \
     && echo "Downloading Gradle" \
     && wget --no-verbose --output-document=gradle.zip "https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip" \

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Use the docker image gradle tool instead of installing the jar on every run.

## PR description
Upgrade gradle to 7.6 for both the CI image and the main build.
Use the docker image gradle tool instead of installing the jar on every run.

