### PR TITLE
Validate genesis is present

### DIFF
--- a/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
+++ b/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
@@ -241,10 +241,13 @@ class EthereumClient(
           )
         }
         val genesisFile = repoToGenesisFile[repository]
+          ?: throw IllegalArgumentException(
+            "Genesis file associated with repository ${rlpxConfig.repository()} not found"
+          )
         val genesisBlock = repository.retrieveGenesisBlock()
         val adapter = WireConnectionPeerRepositoryAdapter(peerRepository)
         val blockchainInfo = SimpleBlockchainInformation(
-          UInt256.valueOf(genesisFile!!.chainId.toLong()),
+          UInt256.valueOf(genesisFile.chainId.toLong()),
           genesisBlock.header.difficulty,
           genesisBlock.header.hash,
           genesisBlock.header.number,


### PR DESCRIPTION
throw an explicit exception in case of misconfiguration of the genesis file associated with the rlpx service.

Fixes #261