### PR TITLE
Use a config setting to set the client service name

### DIFF
--- a/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
+++ b/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClient.kt
@@ -107,7 +107,7 @@ class EthereumClient(
     logger.info("Starting Ethereum client...")
     if (config.metricsEnabled()) {
       val metricsService = MetricsService(
-        "tuweni",
+        config.metricsServiceName(),
         port = config.metricsPort(),
         networkInterface = config.metricsNetworkInterface(),
         enableGrpcPush = config.metricsGrpcPushEnabled(),

--- a/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClientConfig.kt
+++ b/eth-client/src/main/kotlin/org/apache/tuweni/ethclient/EthereumClientConfig.kt
@@ -106,6 +106,8 @@ class EthereumClientConfig(private var config: Configuration = Configuration.emp
 
   fun metricsEnabled(): Boolean = config.getConfigurationSection("metrics").getBoolean("enabled")
 
+  fun metricsServiceName(): String = config.getConfigurationSection("metrics").getString("serviceName")
+
   fun metricsPort(): Int = config.getConfigurationSection("metrics").getInteger("port")
 
   fun metricsNetworkInterface(): String = config.getConfigurationSection("metrics").getString("networkInterface")
@@ -262,6 +264,7 @@ class EthereumClientConfig(private var config: Configuration = Configuration.emp
       metricsSection.addInteger("port", 9090, "Port to expose Prometheus metrics", PropertyValidator.isValidPort())
       metricsSection.addString("networkInterface", "0.0.0.0", "Network interface to expose Prometheus metrics", null)
       metricsSection.addBoolean("enablePrometheus", true, "Enable Prometheus metrics reporting", null)
+      metricsSection.addString("serviceName", "tuweni", "Host service name", null)
       metricsSection.addBoolean("enableGrpcPush", true, "Enable GRPC OpenTelemetry metrics reporting", null)
 
       val storageSection = SchemaBuilder.create()


### PR DESCRIPTION
## PR description
Use a config setting to set the client service name instead of hardcoding to "tuweni". "tuweni" remains the default value.

## Fixed Issue(s)
Fixes #258
